### PR TITLE
I clang formatted the entire code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,7 +26,7 @@ BinPackParameters: false
 BraceWrapping:   
   AfterCaseLabel:  false
   AfterClass:      true
-  AfterControlStatement: false
+  AfterControlStatement: true
   AfterEnum:       false
   AfterFunction:   true
   AfterNamespace:  false
@@ -47,7 +47,7 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit:     80
+ColumnLimit:     160
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true

--- a/Source/Src_3d/advance_3d.H
+++ b/Source/Src_3d/advance_3d.H
@@ -9,18 +9,18 @@ using namespace amrex;
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void update_residual(int i, int j, int k, int n, 
-                     Array4<Real> const& dsdt,
-                     Array4<Real> const &source,
-                     AMREX_D_DECL(Array4<Real> const& flxx,
-                                  Array4<Real> const& flxy,
-                                  Array4<Real> const& flxz),
-                     const GpuArray<Real, AMREX_SPACEDIM>& dx)
+void update_residual(
+    int i,
+    int j,
+    int k,
+    int n,
+    Array4<Real> const& dsdt,
+    Array4<Real> const& source,
+    AMREX_D_DECL(Array4<Real> const& flxx, Array4<Real> const& flxy, Array4<Real> const& flxz),
+    const GpuArray<Real, AMREX_SPACEDIM>& dx)
 {
-    //remember, we are solve dudt + del.F = 0
-    dsdt(i,j,k,n) =   (flxx(i,j,k,n) - flxx(i+1,j,k,n)) / dx[0] 
-                  +   (flxy(i,j,k,n) - flxy(i,j+1,k,n)) / dx[1] 
-                  +   (flxz(i,j,k,n) - flxz(i,j,k+1,n)) / dx[2]
-                  +   source(i,j,k,n);
+    // remember, we are solve dudt + del.F = 0
+    dsdt(i, j, k, n) = (flxx(i, j, k, n) - flxx(i + 1, j, k, n)) / dx[0] + (flxy(i, j, k, n) - flxy(i, j + 1, k, n)) / dx[1] +
+                       (flxz(i, j, k, n) - flxz(i, j, k + 1, n)) / dx[2] + source(i, j, k, n);
 }
 #endif

--- a/Source/Src_3d/compute_flux_3d.H
+++ b/Source/Src_3d/compute_flux_3d.H
@@ -11,125 +11,134 @@ using namespace amrex;
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void compute_flux_x(int i, int j, int k,int n,
-                    Array4<Real> const& phi, //state variable
-                    Array4<Real> const& vel,
-                    Array4<Real> const& dcoeff,
-                    Array4<Real> const& fx,
-                    const GpuArray<Real, AMREX_SPACEDIM>& dx)
+void compute_flux_x(
+    int i,
+    int j,
+    int k,
+    int n,
+    Array4<Real> const& phi, // state variable
+    Array4<Real> const& vel,
+    Array4<Real> const& dcoeff,
+    Array4<Real> const& fx,
+    const GpuArray<Real, AMREX_SPACEDIM>& dx)
 {
 
-    const amrex::Real d1 = dcoeff(i,j,k,n);
-    const amrex::Real d2 = dcoeff(i-1,j,k,n);
-    fx(i,j,k,n) = -2.0 * d1 * d2 / (d1 + d2 + heps) * (phi(i,j,k,n) - phi(i-1,j,k,n))/dx[0];
-//    fx(i,j,k,n) = -0.5 * (dcoeff(i,j,k,n)+dcoeff(i-1,j,k,n)) * (phi(i,j,k,n) - phi(i-1,j,k,n))/dx[0];
-    
-    //find face vel
-    Real smallval  = 1e-10;
-    Real dtr=phi(i,j,k,n) - phi(i-1,j,k,n);
-    if(!(std::abs(dtr) > 0.0))
-    {
-        dtr=dtr+smallval;
-    }
-    Real r_left    = (phi(i-1,j,k,n) - phi(i-2,j,k,n))/dtr;
-    Real lim_left  = std::max(0.0,std::min(1.0,r_left));
+    const amrex::Real d1 = dcoeff(i, j, k, n);
+    const amrex::Real d2 = dcoeff(i - 1, j, k, n);
+    fx(i, j, k, n) = -2.0 * d1 * d2 / (d1 + d2 + heps) * (phi(i, j, k, n) - phi(i - 1, j, k, n)) / dx[0];
+    //    fx(i,j,k,n) = -0.5 * (dcoeff(i,j,k,n)+dcoeff(i-1,j,k,n)) * (phi(i,j,k,n) - phi(i-1,j,k,n))/dx[0];
 
-    dtr=phi(i+1,j,k,n) - phi(i,j,k,n);
-    if(!(std::abs(dtr) > 0.0))
+    // find face vel
+    Real smallval = 1e-10;
+    Real dtr = phi(i, j, k, n) - phi(i - 1, j, k, n);
+    if (!(std::abs(dtr) > 0.0))
     {
-        dtr=dtr+smallval;
+        dtr = dtr + smallval;
     }
-    Real r_right   = (phi(i,j,k,n)  - phi(i-1,j,k,n))/dtr;
-    Real lim_right = std::max(0.0,std::min(1.0,r_right));
-    
-    Real phi_L     = phi(i-1,j,k,n) + 0.5 * lim_left  * (phi(i-1,j,k,n) - phi(i-2,j,k,n));
-    Real phi_R     = phi(i,j,k,n)   - 0.5 * lim_right * (phi(i+1,j,k,n) - phi(i,j,k,n));
+    Real r_left = (phi(i - 1, j, k, n) - phi(i - 2, j, k, n)) / dtr;
+    Real lim_left = std::max(0.0, std::min(1.0, r_left));
 
-    Real vel_mid   = vel(i,j,k,n);
-    fx(i,j,k,n)   += phi_L *0.5 *(vel_mid + fabs(vel_mid))
-                   + phi_R *0.5 *(vel_mid - fabs(vel_mid));
+    dtr = phi(i + 1, j, k, n) - phi(i, j, k, n);
+    if (!(std::abs(dtr) > 0.0))
+    {
+        dtr = dtr + smallval;
+    }
+    Real r_right = (phi(i, j, k, n) - phi(i - 1, j, k, n)) / dtr;
+    Real lim_right = std::max(0.0, std::min(1.0, r_right));
+
+    Real phi_L = phi(i - 1, j, k, n) + 0.5 * lim_left * (phi(i - 1, j, k, n) - phi(i - 2, j, k, n));
+    Real phi_R = phi(i, j, k, n) - 0.5 * lim_right * (phi(i + 1, j, k, n) - phi(i, j, k, n));
+
+    Real vel_mid = vel(i, j, k, n);
+    fx(i, j, k, n) += phi_L * 0.5 * (vel_mid + fabs(vel_mid)) + phi_R * 0.5 * (vel_mid - fabs(vel_mid));
 }
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void compute_flux_y(int i, int j, int k,int n,
-                    Array4<Real> const& phi, //state variable
-                    Array4<Real> const& vel,
-                    Array4<Real> const& dcoeff,
-                    Array4<Real> const& fy,
-                    const GpuArray<Real, AMREX_SPACEDIM>& dx)
+void compute_flux_y(
+    int i,
+    int j,
+    int k,
+    int n,
+    Array4<Real> const& phi, // state variable
+    Array4<Real> const& vel,
+    Array4<Real> const& dcoeff,
+    Array4<Real> const& fy,
+    const GpuArray<Real, AMREX_SPACEDIM>& dx)
 {
 
-    const amrex::Real d1 = dcoeff(i,j,k,n);
-    const amrex::Real d2 = dcoeff(i,j-1,k,n);
-    fy(i,j,k,n) = -2.0 * d1 * d2 / (d1 + d2 + heps) * (phi(i,j,k,n) - phi(i,j-1,k,n))/dx[1];
-//    fy(i,j,k,n) = -0.5 * (dcoeff(i,j,k,n)+dcoeff(i,j-1,k,n)) * (phi(i,j,k,n) - phi(i,j-1,k,n))/dx[1];
+    const amrex::Real d1 = dcoeff(i, j, k, n);
+    const amrex::Real d2 = dcoeff(i, j - 1, k, n);
+    fy(i, j, k, n) = -2.0 * d1 * d2 / (d1 + d2 + heps) * (phi(i, j, k, n) - phi(i, j - 1, k, n)) / dx[1];
+    //    fy(i,j,k,n) = -0.5 * (dcoeff(i,j,k,n)+dcoeff(i,j-1,k,n)) * (phi(i,j,k,n) - phi(i,j-1,k,n))/dx[1];
 
-    //find face vel
-    Real smallval=1e-10;
-    Real dtr=phi(i,j,k,n) - phi(i,j-1,k,n);
-    if(!(std::abs(dtr) > 0.0))
+    // find face vel
+    Real smallval = 1e-10;
+    Real dtr = phi(i, j, k, n) - phi(i, j - 1, k, n);
+    if (!(std::abs(dtr) > 0.0))
     {
-        dtr=dtr+smallval;
+        dtr = dtr + smallval;
     }
-    Real r_left=(phi(i,j-1,k,n) - phi(i,j-2,k,n))/dtr;
-    Real lim_left=std::max(0.0,std::min(1.0,r_left));
-    
-    dtr=phi(i,j+1,k,n) - phi(i,j,k,n);
-    if(!(std::abs(dtr) > 0.0))
-    {
-        dtr=dtr+smallval;
-    }
-    Real r_right=(phi(i,j,k,n) - phi(i,j-1,k,n))/dtr;
-    Real lim_right=std::max(0.0,std::min(1.0,r_right));
-    
-    Real phi_L  = phi(i,j-1,k,n) + 0.5 * lim_left  * (phi(i,j-1,k,n) - phi(i,j-2,k,n));
-    Real phi_R  = phi(i,j,k,n)   - 0.5 * lim_right * (phi(i,j+1,k,n) - phi(i,j,k,n));
+    Real r_left = (phi(i, j - 1, k, n) - phi(i, j - 2, k, n)) / dtr;
+    Real lim_left = std::max(0.0, std::min(1.0, r_left));
 
-    Real vel_mid = vel(i,j,k,n);
-    fy(i,j,k,n)  +=   phi_L * 0.5 *(vel_mid+fabs(vel_mid))
-                    + phi_R * 0.5 *(vel_mid-fabs(vel_mid));
+    dtr = phi(i, j + 1, k, n) - phi(i, j, k, n);
+    if (!(std::abs(dtr) > 0.0))
+    {
+        dtr = dtr + smallval;
+    }
+    Real r_right = (phi(i, j, k, n) - phi(i, j - 1, k, n)) / dtr;
+    Real lim_right = std::max(0.0, std::min(1.0, r_right));
+
+    Real phi_L = phi(i, j - 1, k, n) + 0.5 * lim_left * (phi(i, j - 1, k, n) - phi(i, j - 2, k, n));
+    Real phi_R = phi(i, j, k, n) - 0.5 * lim_right * (phi(i, j + 1, k, n) - phi(i, j, k, n));
+
+    Real vel_mid = vel(i, j, k, n);
+    fy(i, j, k, n) += phi_L * 0.5 * (vel_mid + fabs(vel_mid)) + phi_R * 0.5 * (vel_mid - fabs(vel_mid));
 }
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void compute_flux_z(int i, int j, int k,int n,
-                    Array4<Real> const& phi, //state variable
-                    Array4<Real> const& vel,
-                    Array4<Real> const& dcoeff,
-                    Array4<Real> const& fz,
-                    const GpuArray<Real, AMREX_SPACEDIM>& dx)
+void compute_flux_z(
+    int i,
+    int j,
+    int k,
+    int n,
+    Array4<Real> const& phi, // state variable
+    Array4<Real> const& vel,
+    Array4<Real> const& dcoeff,
+    Array4<Real> const& fz,
+    const GpuArray<Real, AMREX_SPACEDIM>& dx)
 {
 
-    const amrex::Real d1 = dcoeff(i,j,k,n);
-    const amrex::Real d2 = dcoeff(i,j,k-1,n);
-    fz(i,j,k,n) = -2.0 * d1 * d2 / (d1 + d2 + heps) * (phi(i,j,k,n) - phi(i,j,k-1,n))/dx[2];
-//    fz(i,j,k,n) = -0.5 * (dcoeff(i,j,k,n)+dcoeff(i,j,k-1,n)) * (phi(i,j,k,n) - phi(i,j,k-1,n))/dx[2];
+    const amrex::Real d1 = dcoeff(i, j, k, n);
+    const amrex::Real d2 = dcoeff(i, j, k - 1, n);
+    fz(i, j, k, n) = -2.0 * d1 * d2 / (d1 + d2 + heps) * (phi(i, j, k, n) - phi(i, j, k - 1, n)) / dx[2];
+    //    fz(i,j,k,n) = -0.5 * (dcoeff(i,j,k,n)+dcoeff(i,j,k-1,n)) * (phi(i,j,k,n) - phi(i,j,k-1,n))/dx[2];
 
-    //find face vel
-    Real smallval=1e-10;
+    // find face vel
+    Real smallval = 1e-10;
 
-    Real dtr=phi(i,j,k,n) - phi(i,j,k-1,n);
-    if(!(std::abs(dtr) > 0.0))
+    Real dtr = phi(i, j, k, n) - phi(i, j, k - 1, n);
+    if (!(std::abs(dtr) > 0.0))
     {
-        dtr=dtr+smallval;
+        dtr = dtr + smallval;
     }
-    Real r_left=(phi(i,j,k-1,n) - phi(i,j,k-2,n))/dtr;
-    Real lim_left=std::max(0.0,std::min(1.0,r_left));
-    
-    dtr=phi(i,j,k+1,n) - phi(i,j,k,n);
-    if(!(std::abs(dtr) > 0.0))
-    {
-        dtr=dtr+smallval;
-    }
-    Real r_right=(phi(i,j,k,n) - phi(i,j,k-1,n))/dtr;
-    Real lim_right=std::max(0.0,std::min(1.0,r_right));
-    
-    Real phi_L  = phi(i,j,k-1,n) + 0.5 * lim_left  * (phi(i,j,k-1,n) - phi(i,j,k-2,n));
-    Real phi_R  = phi(i,j,k,n  ) - 0.5 * lim_right * (phi(i,j,k+1,n) - phi(i,j,k,n));
+    Real r_left = (phi(i, j, k - 1, n) - phi(i, j, k - 2, n)) / dtr;
+    Real lim_left = std::max(0.0, std::min(1.0, r_left));
 
-    Real vel_mid = vel(i,j,k,n);
-    fz(i,j,k,n)  +=   phi_L *0.5 *(vel_mid+fabs(vel_mid))
-                    + phi_R *0.5 *(vel_mid-fabs(vel_mid));
+    dtr = phi(i, j, k + 1, n) - phi(i, j, k, n);
+    if (!(std::abs(dtr) > 0.0))
+    {
+        dtr = dtr + smallval;
+    }
+    Real r_right = (phi(i, j, k, n) - phi(i, j, k - 1, n)) / dtr;
+    Real lim_right = std::max(0.0, std::min(1.0, r_right));
+
+    Real phi_L = phi(i, j, k - 1, n) + 0.5 * lim_left * (phi(i, j, k - 1, n) - phi(i, j, k - 2, n));
+    Real phi_R = phi(i, j, k, n) - 0.5 * lim_right * (phi(i, j, k + 1, n) - phi(i, j, k, n));
+
+    Real vel_mid = vel(i, j, k, n);
+    fz(i, j, k, n) += phi_L * 0.5 * (vel_mid + fabs(vel_mid)) + phi_R * 0.5 * (vel_mid - fabs(vel_mid));
 }
 #endif

--- a/Source/echemAMR.H
+++ b/Source/echemAMR.H
@@ -42,20 +42,12 @@ public:
     // Make a new level using provided BoxArray and DistributionMapping and
     // fill with interpolated coarse level data.
     // overrides the pure virtual function in AmrCore
-    virtual void MakeNewLevelFromCoarse(
-        int lev,
-        amrex::Real time,
-        const amrex::BoxArray& ba,
-        const amrex::DistributionMapping& dm) override;
+    virtual void MakeNewLevelFromCoarse(int lev, amrex::Real time, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm) override;
 
     // Remake an existing level using provided BoxArray and DistributionMapping
     // and fill with existing fine and coarse data. overrides the pure virtual
     // function in AmrCore
-    virtual void RemakeLevel(
-        int lev,
-        amrex::Real time,
-        const amrex::BoxArray& ba,
-        const amrex::DistributionMapping& dm) override;
+    virtual void RemakeLevel(int lev, amrex::Real time, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm) override;
 
     // Delete level data
     // overrides the pure virtual function in AmrCore
@@ -64,33 +56,15 @@ public:
     // Make a new level from scratch using provided BoxArray and
     // DistributionMapping. Only used during initialization. overrides the pure
     // virtual function in AmrCore
-    virtual void MakeNewLevelFromScratch(
-        int lev,
-        amrex::Real time,
-        const amrex::BoxArray& ba,
-        const amrex::DistributionMapping& dm) override;
+    virtual void MakeNewLevelFromScratch(int lev, amrex::Real time, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm) override;
 
     // tag all cells for refinement
     // overrides the pure virtual function in AmrCore
-    virtual void
-    ErrorEst(int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow)
-        override;
+    virtual void ErrorEst(int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow) override;
 
     // advance a single level for a single time step, updates flux registers
-    void Advance(
-        int lev,
-        amrex::Real time,
-        amrex::Real dt_lev,
-        int iteration,
-        int ncycle);
-    void compute_dsdt(
-        int lev,
-        const int num_grow,
-        MultiFab& Sborder,
-        MultiFab& dsdt,
-        Real time,
-        Real dt,
-        bool reflux_this_stage);
+    void Advance(int lev, amrex::Real time, amrex::Real dt_lev, int iteration, int ncycle);
+    void compute_dsdt(int lev, const int num_grow, MultiFab& Sborder, MultiFab& dsdt, Real time, Real dt, bool reflux_this_stage);
 
     void solve_potential(Real current_time);
 
@@ -106,8 +80,7 @@ public:
     // a wrapper for computing integrals
     Real CurrentCollectorIntegral(int comp, int domain);
 
-    void
-    postprocess(Real time, int timestep, Real dt, GlobalStorage* globalstorage);
+    void postprocess(Real time, int timestep, Real dt, GlobalStorage* globalstorage);
 
     void init_volumes();
 
@@ -128,20 +101,14 @@ private:
     // compute a new multifab by coping in phi from valid region and filling
     // ghost cells works for single level and 2-level cases (fill fine grid
     // ghost by interpolating from coarse)
-    void FillPatch(
-        int lev, amrex::Real time, amrex::MultiFab& mf, int icomp, int ncomp);
+    void FillPatch(int lev, amrex::Real time, amrex::MultiFab& mf, int icomp, int ncomp);
 
     // fill an entire multifab by interpolating from the coarser level
     // this comes into play when a new level of refinement appears
-    void FillCoarsePatch(
-        int lev, amrex::Real time, amrex::MultiFab& mf, int icomp, int ncomp);
+    void FillCoarsePatch(int lev, amrex::Real time, amrex::MultiFab& mf, int icomp, int ncomp);
 
     // utility to copy in data from phi_old and/or phi_new into another multifab
-    void GetData(
-        int lev,
-        amrex::Real time,
-        amrex::Vector<amrex::MultiFab*>& data,
-        amrex::Vector<amrex::Real>& datatime);
+    void GetData(int lev, amrex::Real time, amrex::Vector<amrex::MultiFab*>& data, amrex::Vector<amrex::Real>& datatime);
 
     // advance a level by dt
     // includes a recursive call for finer levels
@@ -212,10 +179,8 @@ private:
     // if >= 0 we restart from a checkpoint
     std::string restart_chkfile = "";
 
-    amrex::Vector<int> bc_lo{BCType::foextrap, BCType::foextrap,
-                             BCType::foextrap};
-    amrex::Vector<int> bc_hi{BCType::foextrap, BCType::foextrap,
-                             BCType::foextrap};
+    amrex::Vector<int> bc_lo{BCType::foextrap, BCType::foextrap, BCType::foextrap};
+    amrex::Vector<int> bc_hi{BCType::foextrap, BCType::foextrap, BCType::foextrap};
 
     // advective cfl number - dt = cfl*dx/umax
     amrex::Real cfl = 0.7;

--- a/Source/echemAMR_BCFill.H
+++ b/Source/echemAMR_BCFill.H
@@ -28,10 +28,8 @@ struct AmrCoreFill
         const amrex::Real* prob_lo = geom.ProbLo();
         const amrex::Real* prob_hi = geom.ProbHi();
         const amrex::Real* dx = geom.CellSize();
-        const amrex::Real x[AMREX_SPACEDIM] = {AMREX_D_DECL(
-            prob_lo[0] + (iv[0] + 0.5) * dx[0],
-            prob_lo[1] + (iv[1] + 0.5) * dx[1],
-            prob_lo[2] + (iv[2] + 0.5) * dx[2])};
+        const amrex::Real x[AMREX_SPACEDIM] = {
+            AMREX_D_DECL(prob_lo[0] + (iv[0] + 0.5) * dx[0], prob_lo[1] + (iv[1] + 0.5) * dx[1], prob_lo[2] + (iv[2] + 0.5) * dx[2])};
 
         const int* bc = bcr->data();
 
@@ -40,68 +38,80 @@ struct AmrCoreFill
 
         // xlo and xhi
         int idir = 0;
-        if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir])) {
+        if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir]))
+        {
             amrex::IntVect loc(AMREX_D_DECL(domlo[idir], iv[1], iv[2]));
-            for (int n = 0; n < NVAR; n++) {
+            for (int n = 0; n < NVAR; n++)
+            {
                 s_int[n] = data(loc, n);
             }
             externalbc(x, s_int, s_ext, idir, +1, time, geom);
-            for (int n = 0; n < NVAR; n++) {
+            for (int n = 0; n < NVAR; n++)
+            {
                 data(iv, n) = s_ext[n];
             }
-        } else if (
-            (bc[idir + AMREX_SPACEDIM] == amrex::BCType::ext_dir) and
-            (iv[idir] > domhi[idir])) {
+        } else if ((bc[idir + AMREX_SPACEDIM] == amrex::BCType::ext_dir) and (iv[idir] > domhi[idir]))
+        {
             amrex::IntVect loc(AMREX_D_DECL(domhi[idir], iv[1], iv[2]));
-            for (int n = 0; n < NVAR; n++) {
+            for (int n = 0; n < NVAR; n++)
+            {
                 s_int[n] = data(loc, n);
             }
             externalbc(x, s_int, s_ext, idir, -1, time, geom);
-            for (int n = 0; n < NVAR; n++) {
+            for (int n = 0; n < NVAR; n++)
+            {
                 data(iv, n) = s_ext[n];
             }
         }
         // ylo and yhi
         idir = 1;
-        if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir])) {
+        if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir]))
+        {
             amrex::IntVect loc(AMREX_D_DECL(iv[0], domlo[idir], iv[2]));
-            for (int n = 0; n < NVAR; n++) {
+            for (int n = 0; n < NVAR; n++)
+            {
                 s_int[n] = data(loc, n);
             }
             externalbc(x, s_int, s_ext, idir, +1, time, geom);
-            for (int n = 0; n < NVAR; n++) {
+            for (int n = 0; n < NVAR; n++)
+            {
                 data(iv, n) = s_ext[n];
             }
-        } else if (
-            (bc[idir + AMREX_SPACEDIM] == amrex::BCType::ext_dir) and
-            (iv[idir] > domhi[idir])) {
+        } else if ((bc[idir + AMREX_SPACEDIM] == amrex::BCType::ext_dir) and (iv[idir] > domhi[idir]))
+        {
             amrex::IntVect loc(AMREX_D_DECL(iv[0], domhi[idir], iv[2]));
-            for (int n = 0; n < NVAR; n++) {
+            for (int n = 0; n < NVAR; n++)
+            {
                 s_int[n] = data(loc, n);
             }
             externalbc(x, s_int, s_ext, idir, -1, time, geom);
-            for (int n = 0; n < NVAR; n++) {
+            for (int n = 0; n < NVAR; n++)
+            {
                 data(iv, n) = s_ext[n];
             }
         }
         // zlo and zhi
         idir = 2;
-        if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir])) {
-            for (int n = 0; n < NVAR; n++) {
+        if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir]))
+        {
+            for (int n = 0; n < NVAR; n++)
+            {
                 s_int[n] = data(iv[0], iv[1], domlo[idir], n);
             }
             externalbc(x, s_int, s_ext, idir, +1, time, geom);
-            for (int n = 0; n < NVAR; n++) {
+            for (int n = 0; n < NVAR; n++)
+            {
                 data(iv, n) = s_ext[n];
             }
-        } else if (
-            (bc[idir + AMREX_SPACEDIM] == amrex::BCType::ext_dir) and
-            (iv[idir] > domhi[idir])) {
-            for (int n = 0; n < NVAR; n++) {
+        } else if ((bc[idir + AMREX_SPACEDIM] == amrex::BCType::ext_dir) and (iv[idir] > domhi[idir]))
+        {
+            for (int n = 0; n < NVAR; n++)
+            {
                 s_int[n] = data(iv[0], iv[1], domhi[idir], n);
             }
             externalbc(x, s_int, s_ext, idir, -1, time, geom);
-            for (int n = 0; n < NVAR; n++) {
+            for (int n = 0; n < NVAR; n++)
+            {
                 data(iv, n) = s_ext[n];
             }
         }

--- a/Source/echemAMR_GridWork.cpp
+++ b/Source/echemAMR_GridWork.cpp
@@ -17,8 +17,7 @@
 // Make a new level using provided BoxArray and DistributionMapping and
 // fill with interpolated coarse level data.
 // overrides the pure virtual function in AmrCore
-void echemAMR::MakeNewLevelFromCoarse(
-    int lev, Real time, const BoxArray& ba, const DistributionMapping& dm)
+void echemAMR::MakeNewLevelFromCoarse(int lev, Real time, const BoxArray& ba, const DistributionMapping& dm)
 {
     const int ncomp = phi_new[lev - 1].nComp();
     const int nghost = phi_new[lev - 1].nGrow();
@@ -29,9 +28,9 @@ void echemAMR::MakeNewLevelFromCoarse(
     t_new[lev] = time;
     t_old[lev] = time - 1.e200;
 
-    if (lev > 0 && do_reflux) {
-        flux_reg[lev].reset(
-            new FluxRegister(ba, dm, refRatio(lev - 1), lev, ncomp));
+    if (lev > 0 && do_reflux)
+    {
+        flux_reg[lev].reset(new FluxRegister(ba, dm, refRatio(lev - 1), lev, ncomp));
     }
 
     FillCoarsePatch(lev, time, phi_new[lev], 0, ncomp);
@@ -40,8 +39,7 @@ void echemAMR::MakeNewLevelFromCoarse(
 // Remake an existing level using provided BoxArray and DistributionMapping and
 // fill with existing fine and coarse data.
 // overrides the pure virtual function in AmrCore
-void echemAMR::RemakeLevel(
-    int lev, Real time, const BoxArray& ba, const DistributionMapping& dm)
+void echemAMR::RemakeLevel(int lev, Real time, const BoxArray& ba, const DistributionMapping& dm)
 {
     const int ncomp = phi_new[lev].nComp();
     const int nghost = phi_new[lev].nGrow();
@@ -57,9 +55,9 @@ void echemAMR::RemakeLevel(
     t_new[lev] = time;
     t_old[lev] = time - 1.e200;
 
-    if (lev > 0 && do_reflux) {
-        flux_reg[lev].reset(
-            new FluxRegister(ba, dm, refRatio(lev - 1), lev, ncomp));
+    if (lev > 0 && do_reflux)
+    {
+        flux_reg[lev].reset(new FluxRegister(ba, dm, refRatio(lev - 1), lev, ncomp));
     }
 }
 
@@ -75,8 +73,7 @@ void echemAMR::ClearLevel(int lev)
 // Make a new level from scratch using provided BoxArray and
 // DistributionMapping. Only used during initialization. overrides the pure
 // virtual function in AmrCore
-void echemAMR::MakeNewLevelFromScratch(
-    int lev, Real time, const BoxArray& ba, const DistributionMapping& dm)
+void echemAMR::MakeNewLevelFromScratch(int lev, Real time, const BoxArray& ba, const DistributionMapping& dm)
 {
     const int nghost = 0;
     int ncomp = NVAR;
@@ -87,22 +84,22 @@ void echemAMR::MakeNewLevelFromScratch(
     t_new[lev] = time;
     t_old[lev] = time - 1.e200;
 
-    if (lev > 0 && do_reflux) {
-        flux_reg[lev].reset(
-            new FluxRegister(ba, dm, refRatio(lev - 1), lev, ncomp));
+    if (lev > 0 && do_reflux)
+    {
+        flux_reg[lev].reset(new FluxRegister(ba, dm, refRatio(lev - 1), lev, ncomp));
     }
 
     Real cur_time = t_new[lev];
     MultiFab& state = phi_new[lev];
 
-    for (MFIter mfi(state); mfi.isValid(); ++mfi) {
+    for (MFIter mfi(state); mfi.isValid(); ++mfi)
+    {
         Array4<Real> fab = state[mfi].array();
         GeometryData geomData = geom[lev].data();
         const Box& box = mfi.validbox();
 
         amrex::launch(box, [=] AMREX_GPU_DEVICE(Box const& tbx) {
-            initdomaindata(
-                tbx, fab, geomData); // init just mesh refinement stuff
+            initdomaindata(tbx, fab, geomData); // init just mesh refinement stuff
         });
     }
 }
@@ -110,10 +107,9 @@ void echemAMR::MakeNewLevelFromScratch(
 // set covered coarse cells to be the average of overlying fine cells
 void echemAMR::AverageDown()
 {
-    for (int lev = finest_level - 1; lev >= 0; --lev) {
-        amrex::average_down(
-            phi_new[lev + 1], phi_new[lev], geom[lev + 1], geom[lev], 0,
-            phi_new[lev].nComp(), refRatio(lev));
+    for (int lev = finest_level - 1; lev >= 0; --lev)
+    {
+        amrex::average_down(phi_new[lev + 1], phi_new[lev], geom[lev + 1], geom[lev], 0, phi_new[lev].nComp(), refRatio(lev));
     }
 }
 
@@ -121,9 +117,7 @@ void echemAMR::AverageDown()
 // multiple levels
 void echemAMR::AverageDownTo(int crse_lev)
 {
-    amrex::average_down(
-        phi_new[crse_lev + 1], phi_new[crse_lev], geom[crse_lev + 1],
-        geom[crse_lev], 0, phi_new[crse_lev].nComp(), refRatio(crse_lev));
+    amrex::average_down(phi_new[crse_lev + 1], phi_new[crse_lev], geom[crse_lev + 1], geom[crse_lev], 0, phi_new[crse_lev].nComp(), refRatio(crse_lev));
 }
 
 // compute a new multifab by coping in phi from valid region and filling ghost
@@ -131,17 +125,17 @@ void echemAMR::AverageDownTo(int crse_lev)
 // interpolating from coarse)
 void echemAMR::FillPatch(int lev, Real time, MultiFab& mf, int icomp, int ncomp)
 {
-    if (lev == 0) {
+    if (lev == 0)
+    {
         Vector<MultiFab*> smf;
         Vector<Real> stime;
         GetData(0, time, smf, stime);
 
         GpuBndryFuncFab<AmrCoreFill> gpu_bndry_func(amrcore_fill_func);
-        PhysBCFunct<GpuBndryFuncFab<AmrCoreFill>> physbc(
-            geom[lev], bcs, gpu_bndry_func);
-        amrex::FillPatchSingleLevel(
-            mf, time, smf, stime, 0, icomp, ncomp, geom[lev], physbc, 0);
-    } else {
+        PhysBCFunct<GpuBndryFuncFab<AmrCoreFill>> physbc(geom[lev], bcs, gpu_bndry_func);
+        amrex::FillPatchSingleLevel(mf, time, smf, stime, 0, icomp, ncomp, geom[lev], physbc, 0);
+    } else
+    {
         Vector<MultiFab*> cmf, fmf;
         Vector<Real> ctime, ftime;
         GetData(lev - 1, time, cmf, ctime);
@@ -150,22 +144,17 @@ void echemAMR::FillPatch(int lev, Real time, MultiFab& mf, int icomp, int ncomp)
         Interpolater* mapper = &cell_cons_interp;
 
         GpuBndryFuncFab<AmrCoreFill> gpu_bndry_func(amrcore_fill_func);
-        PhysBCFunct<GpuBndryFuncFab<AmrCoreFill>> cphysbc(
-            geom[lev - 1], bcs, gpu_bndry_func);
-        PhysBCFunct<GpuBndryFuncFab<AmrCoreFill>> fphysbc(
-            geom[lev], bcs, gpu_bndry_func);
+        PhysBCFunct<GpuBndryFuncFab<AmrCoreFill>> cphysbc(geom[lev - 1], bcs, gpu_bndry_func);
+        PhysBCFunct<GpuBndryFuncFab<AmrCoreFill>> fphysbc(geom[lev], bcs, gpu_bndry_func);
 
         amrex::FillPatchTwoLevels(
-            mf, time, cmf, ctime, fmf, ftime, 0, icomp, ncomp, geom[lev - 1],
-            geom[lev], cphysbc, 0, fphysbc, 0, refRatio(lev - 1), mapper, bcs,
-            0);
+            mf, time, cmf, ctime, fmf, ftime, 0, icomp, ncomp, geom[lev - 1], geom[lev], cphysbc, 0, fphysbc, 0, refRatio(lev - 1), mapper, bcs, 0);
     }
 }
 
 // fill an entire multifab by interpolating from the coarser level
 // this comes into play when a new level of refinement appears
-void echemAMR::FillCoarsePatch(
-    int lev, Real time, MultiFab& mf, int icomp, int ncomp)
+void echemAMR::FillCoarsePatch(int lev, Real time, MultiFab& mf, int icomp, int ncomp)
 {
     BL_ASSERT(lev > 0);
 
@@ -174,17 +163,14 @@ void echemAMR::FillCoarsePatch(
     GetData(lev - 1, time, cmf, ctime);
     Interpolater* mapper = &cell_cons_interp;
 
-    if (cmf.size() != 1) {
+    if (cmf.size() != 1)
+    {
         amrex::Abort("FillCoarsePatch: how did this happen?");
     }
 
     GpuBndryFuncFab<AmrCoreFill> gpu_bndry_func(amrcore_fill_func);
-    PhysBCFunct<GpuBndryFuncFab<AmrCoreFill>> cphysbc(
-        geom[lev - 1], bcs, gpu_bndry_func);
-    PhysBCFunct<GpuBndryFuncFab<AmrCoreFill>> fphysbc(
-        geom[lev], bcs, gpu_bndry_func);
+    PhysBCFunct<GpuBndryFuncFab<AmrCoreFill>> cphysbc(geom[lev - 1], bcs, gpu_bndry_func);
+    PhysBCFunct<GpuBndryFuncFab<AmrCoreFill>> fphysbc(geom[lev], bcs, gpu_bndry_func);
 
-    amrex::InterpFromCoarseLevel(
-        mf, time, *cmf[0], 0, icomp, ncomp, geom[lev - 1], geom[lev], cphysbc,
-        0, fphysbc, 0, refRatio(lev - 1), mapper, bcs, 0);
+    amrex::InterpFromCoarseLevel(mf, time, *cmf[0], 0, icomp, ncomp, geom[lev - 1], geom[lev], cphysbc, 0, fphysbc, 0, refRatio(lev - 1), mapper, bcs, 0);
 }

--- a/Source/echemAMR_Integrate.cpp
+++ b/Source/echemAMR_Integrate.cpp
@@ -11,7 +11,8 @@ Real echemAMR::VolumeIntegral(int comp, int domain)
 {
     Real int_tmp = 0;
     Real exact_con;
-    for (int lev = 0; lev <= finest_level; ++lev) {
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
 
         const auto dx = geom[lev].CellSizeArray();
 
@@ -26,17 +27,11 @@ Real echemAMR::VolumeIntegral(int comp, int domain)
         // need to implement the mask feature from
         // https://github.com/Exawind/amr-wind/blob/main/amr-wind/utilities/sampling/Enstrophy.cpp
 
-        Real nm1 = amrex::ReduceSum(
-            S_new, lev,
-            [=] AMREX_GPU_HOST_DEVICE(
-                Box const& bx, Array4<Real const> const& fab) -> Real {
-                Real r = 0.0;
-                AMREX_LOOP_3D(bx, i, j, k, {
-                    r += electrochem_integral_utils::volume_value(
-                        i, j, k, comp, domain, fab, dx);
-                });
-                return r;
-            });
+        Real nm1 = amrex::ReduceSum(S_new, lev, [=] AMREX_GPU_HOST_DEVICE(Box const& bx, Array4<Real const> const& fab) -> Real {
+            Real r = 0.0;
+            AMREX_LOOP_3D(bx, i, j, k, { r += electrochem_integral_utils::volume_value(i, j, k, comp, domain, fab, dx); });
+            return r;
+        });
 
         ParallelAllReduce::Sum(nm1, ParallelContext::CommunicatorSub());
 
@@ -59,7 +54,8 @@ Real echemAMR::SurfaceIntegral(int comp, int domain1, int domain2)
 {
     Real int_tmp = 0;
     Real exact_con;
-    for (int lev = 0; lev <= finest_level; ++lev) {
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
 
         const auto dx = geom[lev].CellSizeArray();
 
@@ -78,17 +74,11 @@ Real echemAMR::SurfaceIntegral(int comp, int domain1, int domain2)
         // need to implement the mask feature from
         // https://github.com/Exawind/amr-wind/blob/main/amr-wind/utilities/sampling/Enstrophy.cpp
 
-        Real nm1 = amrex::ReduceSum(
-            Sborder, lev,
-            [=] AMREX_GPU_HOST_DEVICE(
-                Box const& bx, Array4<Real const> const& fab) -> Real {
-                Real r = 0.0;
-                AMREX_LOOP_3D(bx, i, j, k, {
-                    r += electrochem_integral_utils::surface_value(
-                        i, j, k, comp, domain1, domain2, fab, domlo, domhi, dx);
-                });
-                return r;
-            });
+        Real nm1 = amrex::ReduceSum(Sborder, lev, [=] AMREX_GPU_HOST_DEVICE(Box const& bx, Array4<Real const> const& fab) -> Real {
+            Real r = 0.0;
+            AMREX_LOOP_3D(bx, i, j, k, { r += electrochem_integral_utils::surface_value(i, j, k, comp, domain1, domain2, fab, domlo, domhi, dx); });
+            return r;
+        });
 
         ParallelAllReduce::Sum(nm1, ParallelContext::CommunicatorSub());
 
@@ -111,7 +101,8 @@ Real echemAMR::CurrentCollectorIntegral(int comp, int domain)
 {
     Real int_tmp = 0;
     Real exact_con;
-    for (int lev = 0; lev <= finest_level; ++lev) {
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
 
         const auto dx = geom[lev].CellSizeArray();
 
@@ -130,17 +121,11 @@ Real echemAMR::CurrentCollectorIntegral(int comp, int domain)
         // need to implement the mask feature from
         // https://github.com/Exawind/amr-wind/blob/main/amr-wind/utilities/sampling/Enstrophy.cpp
 
-        Real nm1 = amrex::ReduceSum(
-            Sborder, lev,
-            [=] AMREX_GPU_HOST_DEVICE(
-                Box const& bx, Array4<Real const> const& fab) -> Real {
-                Real r = 0.0;
-                AMREX_LOOP_3D(bx, i, j, k, {
-                    r += electrochem_integral_utils::current_collector_value(
-                        i, j, k, comp, domain, fab, domlo, domhi, dx);
-                });
-                return r;
-            });
+        Real nm1 = amrex::ReduceSum(Sborder, lev, [=] AMREX_GPU_HOST_DEVICE(Box const& bx, Array4<Real const> const& fab) -> Real {
+            Real r = 0.0;
+            AMREX_LOOP_3D(bx, i, j, k, { r += electrochem_integral_utils::current_collector_value(i, j, k, comp, domain, fab, domlo, domhi, dx); });
+            return r;
+        });
 
         ParallelAllReduce::Sum(nm1, ParallelContext::CommunicatorSub());
 

--- a/Source/echemAMR_Plot.cpp
+++ b/Source/echemAMR_Plot.cpp
@@ -22,16 +22,14 @@ void echemAMR::GotoNextLine(std::istream& is)
 }
 
 // get plotfile name
-std::string echemAMR::PlotFileName(int lev) const
-{
-    return amrex::Concatenate(plot_file, lev, 5);
-}
+std::string echemAMR::PlotFileName(int lev) const { return amrex::Concatenate(plot_file, lev, 5); }
 
 // put together an array of multifabs for writing
 Vector<const MultiFab*> echemAMR::PlotFileMF() const
 {
     Vector<const MultiFab*> r;
-    for (int i = 0; i <= finest_level; ++i) {
+    for (int i = 0; i <= finest_level; ++i)
+    {
         r.push_back(&phi_new[i]);
     }
     return r;
@@ -44,7 +42,8 @@ Vector<std::string> echemAMR::PlotFileVarNames() const
 
     allnames.resize(NVAR);
 
-    for (int i = 0; i < NUM_SPECIES; i++) {
+    for (int i = 0; i < NUM_SPECIES; i++)
+    {
         allnames[i] = electrochem::specnames[i];
     }
     allnames[NVAR - 4] = "Efieldx";
@@ -64,9 +63,7 @@ void echemAMR::WritePlotFile() const
 
     amrex::Print() << "Writing plotfile " << plotfilename << "\n";
 
-    amrex::WriteMultiLevelPlotfile(
-        plotfilename, finest_level + 1, mf, varnames, Geom(), t_new[0], istep,
-        refRatio());
+    amrex::WriteMultiLevelPlotfile(plotfilename, finest_level + 1, mf, varnames, Geom(), t_new[0], istep, refRatio());
 }
 
 void echemAMR::WriteCheckpointFile() const
@@ -98,16 +95,16 @@ void echemAMR::WriteCheckpointFile() const
     amrex::PreBuildDirectorHierarchy(checkpointname, "Level_", nlevels, true);
 
     // write Header file
-    if (ParallelDescriptor::IOProcessor()) {
+    if (ParallelDescriptor::IOProcessor())
+    {
 
         std::string HeaderFileName(checkpointname + "/Header");
         VisMF::IO_Buffer io_buffer(VisMF::IO_Buffer_Size);
         std::ofstream HeaderFile;
         HeaderFile.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
-        HeaderFile.open(
-            HeaderFileName.c_str(),
-            std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
-        if (!HeaderFile.good()) {
+        HeaderFile.open(HeaderFileName.c_str(), std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
+        if (!HeaderFile.good())
+        {
             amrex::FileOpenFailed(HeaderFileName);
         }
 
@@ -120,35 +117,38 @@ void echemAMR::WriteCheckpointFile() const
         HeaderFile << finest_level << "\n";
 
         // write out array of istep
-        for (int i = 0; i < istep.size(); ++i) {
+        for (int i = 0; i < istep.size(); ++i)
+        {
             HeaderFile << istep[i] << " ";
         }
         HeaderFile << "\n";
 
         // write out array of dt
-        for (int i = 0; i < dt.size(); ++i) {
+        for (int i = 0; i < dt.size(); ++i)
+        {
             HeaderFile << dt[i] << " ";
         }
         HeaderFile << "\n";
 
         // write out array of t_new
-        for (int i = 0; i < t_new.size(); ++i) {
+        for (int i = 0; i < t_new.size(); ++i)
+        {
             HeaderFile << t_new[i] << " ";
         }
         HeaderFile << "\n";
 
         // write the BoxArray at each level
-        for (int lev = 0; lev <= finest_level; ++lev) {
+        for (int lev = 0; lev <= finest_level; ++lev)
+        {
             boxArray(lev).writeOn(HeaderFile);
             HeaderFile << '\n';
         }
     }
 
     // write the MultiFab data to, e.g., chk00010/Level_0/
-    for (int lev = 0; lev <= finest_level; ++lev) {
-        VisMF::Write(
-            phi_new[lev], amrex::MultiFabFileFullPrefix(
-                              lev, checkpointname, "Level_", "phi"));
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
+        VisMF::Write(phi_new[lev], amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "phi"));
     }
 }
 
@@ -181,7 +181,8 @@ void echemAMR::ReadCheckpointFile()
     {
         std::istringstream lis(line);
         int i = 0;
-        while (lis >> word) {
+        while (lis >> word)
+        {
             istep[i++] = std::stoi(word);
         }
     }
@@ -191,7 +192,8 @@ void echemAMR::ReadCheckpointFile()
     {
         std::istringstream lis(line);
         int i = 0;
-        while (lis >> word) {
+        while (lis >> word)
+        {
             dt[i++] = std::stod(word);
         }
     }
@@ -201,12 +203,14 @@ void echemAMR::ReadCheckpointFile()
     {
         std::istringstream lis(line);
         int i = 0;
-        while (lis >> word) {
+        while (lis >> word)
+        {
             t_new[i++] = std::stod(word);
         }
     }
 
-    for (int lev = 0; lev <= finest_level; ++lev) {
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
 
         // read in level 'lev' BoxArray from Header
         BoxArray ba;
@@ -226,16 +230,15 @@ void echemAMR::ReadCheckpointFile()
         int nghost = 0;
         phi_old[lev].define(grids[lev], dmap[lev], ncomp, nghost);
         phi_new[lev].define(grids[lev], dmap[lev], ncomp, nghost);
-        if (lev > 0 && do_reflux) {
-            flux_reg[lev].reset(new FluxRegister(
-                grids[lev], dmap[lev], refRatio(lev - 1), lev, ncomp));
+        if (lev > 0 && do_reflux)
+        {
+            flux_reg[lev].reset(new FluxRegister(grids[lev], dmap[lev], refRatio(lev - 1), lev, ncomp));
         }
     }
 
     // read in the MultiFab data
-    for (int lev = 0; lev <= finest_level; ++lev) {
-        VisMF::Read(
-            phi_new[lev], amrex::MultiFabFileFullPrefix(
-                              lev, restart_chkfile, "Level_", "phi"));
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
+        VisMF::Read(phi_new[lev], amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "phi"));
     }
 }

--- a/Source/echemAMR_Tagging.H
+++ b/Source/echemAMR_Tagging.H
@@ -17,9 +17,11 @@ void state_based_refinement(
     char tagval)
 {
 
-    for (int c = 0; c < ntagvars; c++) {
+    for (int c = 0; c < ntagvars; c++)
+    {
         int comp = refine_phi_comps[c];
-        if (std::abs(state(i, j, k, comp)) > refine_phi[c]) {
+        if (std::abs(state(i, j, k, comp)) > refine_phi[c])
+        {
             tag(i, j, k) = tagval;
         }
     }
@@ -39,28 +41,24 @@ void stategrad_based_refinement(
     char tagval)
 {
 
-    for (int c = 0; c < ntagvars; c++) {
+    for (int c = 0; c < ntagvars; c++)
+    {
         int comp = refine_phi_comps[c];
 
-        amrex::Real gradxplus =
-            std::abs(state(i + 1, j, k, comp) - state(i, j, k, comp));
-        amrex::Real gradxminus =
-            std::abs(state(i, j, k, comp) - state(i - 1, j, k, comp));
+        amrex::Real gradxplus = std::abs(state(i + 1, j, k, comp) - state(i, j, k, comp));
+        amrex::Real gradxminus = std::abs(state(i, j, k, comp) - state(i - 1, j, k, comp));
         amrex::Real gradx = amrex::max(gradxplus, gradxminus);
 
-        amrex::Real gradyplus =
-            std::abs(state(i, j + 1, k, comp) - state(i, j, k, comp));
-        amrex::Real gradyminus =
-            std::abs(state(i, j, k, comp) - state(i, j - 1, k, comp));
+        amrex::Real gradyplus = std::abs(state(i, j + 1, k, comp) - state(i, j, k, comp));
+        amrex::Real gradyminus = std::abs(state(i, j, k, comp) - state(i, j - 1, k, comp));
         amrex::Real grady = amrex::max(gradyplus, gradyminus);
 
-        amrex::Real gradzplus =
-            std::abs(state(i, j, k + 1, comp) - state(i, j, k, comp));
-        amrex::Real gradzminus =
-            std::abs(state(i, j, k, comp) - state(i, j, k - 1, comp));
+        amrex::Real gradzplus = std::abs(state(i, j, k + 1, comp) - state(i, j, k, comp));
+        amrex::Real gradzminus = std::abs(state(i, j, k, comp) - state(i, j, k - 1, comp));
         amrex::Real gradz = amrex::max(gradzplus, gradzminus);
 
-        if (amrex::max(gradx, grady, gradz) > refine_phigrad[c]) {
+        if (amrex::max(gradx, grady, gradz) > refine_phigrad[c])
+        {
             tag(i, j, k) = tagval;
         }
     }

--- a/Source/echemAMR_TimeStep.cpp
+++ b/Source/echemAMR_TimeStep.cpp
@@ -20,7 +20,8 @@ void echemAMR::ComputeDt()
 {
     Vector<Real> dt_tmp(finest_level + 1);
 
-    for (int lev = 0; lev <= finest_level; ++lev) {
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
         dt_tmp[lev] = EstTimeStep(lev, true);
     }
     ParallelDescriptor::ReduceRealMin(&dt_tmp[0], dt_tmp.size());
@@ -28,7 +29,8 @@ void echemAMR::ComputeDt()
     constexpr Real change_max = 1.1;
     Real dt_0 = dt_tmp[0];
     int n_factor = 1;
-    for (int lev = 0; lev <= finest_level; ++lev) {
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
         dt_tmp[lev] = std::min(dt_tmp[lev], change_max * dt[lev]);
         n_factor *= nsubsteps[lev];
         dt_0 = std::min(dt_0, n_factor * dt_tmp[lev]);
@@ -36,12 +38,14 @@ void echemAMR::ComputeDt()
 
     // Limit dt's by the value of stop_time.
     const Real eps = 1.e-3 * dt_0;
-    if (t_new[0] + dt_0 > stop_time - eps) {
+    if (t_new[0] + dt_0 > stop_time - eps)
+    {
         dt_0 = stop_time - t_new[0];
     }
 
     dt[0] = dt_0;
-    for (int lev = 1; lev <= finest_level; ++lev) {
+    for (int lev = 1; lev <= finest_level; ++lev)
+    {
         dt[lev] = dt[lev - 1] / nsubsteps[lev];
     }
 }
@@ -65,8 +69,7 @@ Real echemAMR::EstTimeStep(int lev, bool local)
     MultiFab Sborder(grids[lev], dmap[lev], S_new.nComp(), num_grow);
     FillPatch(lev, cur_time, Sborder, 0, Sborder.nComp());
 
-    MultiFab dcoeff(
-        S_new.boxArray(), S_new.DistributionMap(), S_new.nComp(), 0);
+    MultiFab dcoeff(S_new.boxArray(), S_new.DistributionMap(), S_new.nComp(), 0);
     MultiFab vel(S_new.boxArray(), S_new.DistributionMap(), S_new.nComp(), 0);
 
     // set sane default values
@@ -79,7 +82,8 @@ Real echemAMR::EstTimeStep(int lev, bool local)
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
-        for (MFIter mfi(S_new, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        for (MFIter mfi(S_new, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
             const Box& bx = mfi.tilebox();
             Box bx_x = convert(bx, {1, 0, 0});
             Box bx_y = convert(bx, {0, 1, 0});
@@ -106,37 +110,27 @@ Real echemAMR::EstTimeStep(int lev, bool local)
             Array4<Real> velzarray = velz_fab.array();
 
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                electrochem_transport::compute_dcoeff(
-                    i, j, k, statearray, dcoeffarray, prob_lo, prob_hi, dx,
-                    cur_time, *localprobparm);
+                electrochem_transport::compute_dcoeff(i, j, k, statearray, dcoeffarray, prob_lo, prob_hi, dx, cur_time, *localprobparm);
             });
 
             amrex::ParallelFor(bx_x, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                electrochem_transport::compute_velx(
-                    i, j, k, statearray, velxarray, prob_lo, prob_hi, dx,
-                    cur_time, *localprobparm);
+                electrochem_transport::compute_velx(i, j, k, statearray, velxarray, prob_lo, prob_hi, dx, cur_time, *localprobparm);
             });
 
             amrex::ParallelFor(bx_y, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                electrochem_transport::compute_vely(
-                    i, j, k, statearray, velyarray, prob_lo, prob_hi, dx,
-                    cur_time, *localprobparm);
+                electrochem_transport::compute_vely(i, j, k, statearray, velyarray, prob_lo, prob_hi, dx, cur_time, *localprobparm);
             });
 
             amrex::ParallelFor(bx_z, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                electrochem_transport::compute_velz(
-                    i, j, k, statearray, velzarray, prob_lo, prob_hi, dx,
-                    cur_time, *localprobparm);
+                electrochem_transport::compute_velz(i, j, k, statearray, velzarray, prob_lo, prob_hi, dx, cur_time, *localprobparm);
             });
 
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                for (int comp = 0; comp < ncomp; comp++) {
-                    Real vx = 0.5 * (velxarray(i, j, k, comp) +
-                                     velxarray(i + 1, j, k, comp));
-                    Real vy = 0.5 * (velyarray(i, j, k, comp) +
-                                     velyarray(i, j + 1, k, comp));
-                    Real vz = 0.5 * (velzarray(i, j, k, comp) +
-                                     velzarray(i, j, k + 1, comp));
+                for (int comp = 0; comp < ncomp; comp++)
+                {
+                    Real vx = 0.5 * (velxarray(i, j, k, comp) + velxarray(i + 1, j, k, comp));
+                    Real vy = 0.5 * (velyarray(i, j, k, comp) + velyarray(i, j + 1, k, comp));
+                    Real vz = 0.5 * (velzarray(i, j, k, comp) + velzarray(i, j, k + 1, comp));
 
                     velarray(i, j, k, comp) = sqrt(vx * vx + vy * vy + vz * vz);
                 }
@@ -146,26 +140,32 @@ Real echemAMR::EstTimeStep(int lev, bool local)
 
     Real maxdcoeff = 1e-50;
     // only loop over species
-    for (int comp = 0; comp < NUM_SPECIES; comp++) {
+    for (int comp = 0; comp < NUM_SPECIES; comp++)
+    {
         Real diffcomp = dcoeff.norm0(comp, 0, true);
-        if (diffcomp > maxdcoeff) {
+        if (diffcomp > maxdcoeff)
+        {
             maxdcoeff = diffcomp;
         }
     }
-    for (int i = 0; i < AMREX_SPACEDIM; i++) {
-        dt_est = std::min(
-            dt_est, (0.5 / AMREX_SPACEDIM) * (dx[i] * dx[i]) / maxdcoeff);
+    for (int i = 0; i < AMREX_SPACEDIM; i++)
+    {
+        dt_est = std::min(dt_est, (0.5 / AMREX_SPACEDIM) * (dx[i] * dx[i]) / maxdcoeff);
     }
 
     Real maxvel = 1e-50;
-    for (int comp = 0; comp < NUM_SPECIES; comp++) {
+    for (int comp = 0; comp < NUM_SPECIES; comp++)
+    {
         Real velcomp = vel.norm0(comp, 0, true);
-        if (velcomp > maxvel) {
+        if (velcomp > maxvel)
+        {
             maxvel = velcomp;
         }
     }
-    if (maxvel > 0.0) {
-        for (int i = 0; i < AMREX_SPACEDIM; i++) {
+    if (maxvel > 0.0)
+    {
+        for (int i = 0; i < AMREX_SPACEDIM; i++)
+        {
             dt_est = std::min(dt_est, (dx[i] / maxvel));
         }
     }
@@ -181,7 +181,8 @@ Real echemAMR::EstTimeStep(int lev, bool local)
 
     // Currently, this never happens (function called with local = true).
     // Reduction occurs outside this function.
-    if (!local) {
+    if (!local)
+    {
         ParallelDescriptor::ReduceRealMin(dt_est);
     }
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -37,9 +37,9 @@ int main(int argc, char* argv[])
         Real end_total = amrex::second() - strt_total;
 
         // print wallclock time
-        ParallelDescriptor::ReduceRealMax(
-            end_total, ParallelDescriptor::IOProcessorNumber());
-        if (echem_obj.Verbose()) {
+        ParallelDescriptor::ReduceRealMax(end_total, ParallelDescriptor::IOProcessorNumber());
+        if (echem_obj.Verbose())
+        {
             amrex::Print() << "\nTotal Time: " << end_total << '\n';
         }
     }

--- a/test/battery/Chemistry.H
+++ b/test/battery/Chemistry.H
@@ -28,39 +28,36 @@
 
 namespace electrochem {
 
-enum component {
-    anode = 0,
-    cathode,
-    electrolyte,
-    separator,
-    last_comp = separator
-};
+enum component { anode = 0, cathode, electrolyte, separator, last_comp = separator };
 
 extern amrex::Vector<std::string> specnames;
 void init();
 void close();
 int find_id(std::string specname);
 
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE int level_set_to_component(
-    int i, int j, int k, amrex::Array4<amrex::Real> const& phase)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE int level_set_to_component(int i, int j, int k, amrex::Array4<amrex::Real> const& phase)
 {
 
     int comp = -1;
     int ncomp = 0;
 
-    if (phase(i, j, k, A_ID) > 0.0) {
+    if (phase(i, j, k, A_ID) > 0.0)
+    {
         comp = anode;
         ++ncomp;
     }
-    if (phase(i, j, k, C_ID) > 0.0) {
+    if (phase(i, j, k, C_ID) > 0.0)
+    {
         comp = cathode;
         ++ncomp;
     }
-    if (phase(i, j, k, E_ID) > 0.0) {
+    if (phase(i, j, k, E_ID) > 0.0)
+    {
         comp = electrolyte;
         ++ncomp;
     }
-    if (phase(i, j, k, S_ID) > 0.0) {
+    if (phase(i, j, k, S_ID) > 0.0)
+    {
         comp = separator;
         ++ncomp;
     }
@@ -68,12 +65,14 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE int level_set_to_component(
     // FIXME: need to make sure we only do this for real cells and not ghost
     // cells
 #ifndef AMREX_USE_GPU
-    if (comp == -1) {
+    if (comp == -1)
+    {
         amrex::Print() << i << ' ' << j << ' ' << k << std::endl;
         amrex::Abort("error component not found");
     }
 
-    if (ncomp > 1) {
+    if (ncomp > 1)
+    {
         amrex::Print() << i << ' ' << j << ' ' << k << std::endl;
         amrex::Abort("too many components found");
     }
@@ -82,8 +81,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE int level_set_to_component(
     return comp;
 }
 
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool
-is_electrode(int i, int j, int k, amrex::Array4<amrex::Real> const& phase)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool is_electrode(int i, int j, int k, amrex::Array4<amrex::Real> const& phase)
 {
 
     auto comp = level_set_to_component(i, j, k, phase);
@@ -107,34 +105,32 @@ is_electrode(int i, int j, int k, amrex::Array4<amrex::Real> const& phase)
 // (lowerscale_vf_pore_*, and lowerscale_p_pore_*), currently all set with anode
 // parameter
 //         use const int comp = electrochem::level_set_to_component(i,j,k,phi);
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-XeffXbulk(const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real XeffXbulk(const ProbParm& prob_parm)
 {
-    amrex::Real Xeff_Xbulk = pow(
-        prob_parm.lowerscale_vf_pore_anode, prob_parm.lowerscale_p_pore_anode);
+    amrex::Real Xeff_Xbulk = pow(prob_parm.lowerscale_vf_pore_anode, prob_parm.lowerscale_p_pore_anode);
     return Xeff_Xbulk;
 }
 
 // Electrolyte conductivity [S.m-1]. Bulk value, not be used directly in
 // transport equations Ce in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-Ke_Bulk(amrex::Real Ce, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real Ke_Bulk(amrex::Real Ce, const ProbParm& prob_parm)
 {
 
-    if (prob_parm.mater_electrolyte == 0) {
+    if (prob_parm.mater_electrolyte == 0)
+    {
         amrex::Real Kebulk = 0.97274;
         return Kebulk;
-    } else if (prob_parm.mater_electrolyte == 1) {
+    } else if (prob_parm.mater_electrolyte == 1)
+    {
         constexpr amrex::Real a4 = -3.334591539362114e-14;
         constexpr amrex::Real a3 = 3.867473118129116e-10;
         constexpr amrex::Real a2 = -1.559193894834466e-06;
         constexpr amrex::Real a1 = 0.002182354774294;
-        constexpr amrex::Real a0 =
-            0.0; // MUST BE ZERO FOR MODIFED EXPRESSION OF DIFFUSIONAL
-                 // CONDUCTIVITY TO BE CORRECT
-        return amrex::max(
-            (((a4 * Ce + a3) * Ce + a2) * Ce + a1) * Ce + a0, myeps);
-    } else {
+        constexpr amrex::Real a0 = 0.0; // MUST BE ZERO FOR MODIFED EXPRESSION OF DIFFUSIONAL
+                                        // CONDUCTIVITY TO BE CORRECT
+        return amrex::max((((a4 * Ce + a3) * Ce + a2) * Ce + a1) * Ce + a0, myeps);
+    } else
+    {
         amrex::Abort(
             "Incorrect user-parameter mater_electrolyte in "
             "ChemistryProbParm.H");
@@ -144,8 +140,7 @@ Ke_Bulk(amrex::Real Ce, const ProbParm& prob_parm)
 
 // Electrolyte conductivity [S.m-1]. Actual value to be used in transport
 // equations Ce in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-KeC(amrex::Real Ce, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real KeC(amrex::Real Ce, const ProbParm& prob_parm)
 {
     amrex::Real Xeff_Xbulk = XeffXbulk(prob_parm);
     amrex::Real Xbulk = Ke_Bulk(Ce, prob_parm);
@@ -155,8 +150,7 @@ KeC(amrex::Real Ce, const ProbParm& prob_parm)
 
 // Modified electrolyte conductivity (Ke bulk / Ce) for modified expression of
 // the diffusional conductivity
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-Ke_Bulk_star(amrex::Real Ce, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real Ke_Bulk_star(amrex::Real Ce, const ProbParm& prob_parm)
 {
     // Coefficients must be identical with Electrolyte conductivity Kebulk
     constexpr amrex::Real a4 = -3.334591539362114e-14;
@@ -170,8 +164,7 @@ Ke_Bulk_star(amrex::Real Ce, const ProbParm& prob_parm)
 
 // Modified electrolyte conductivity (Ke / Ce) for modified expression of the
 // diffusional conductivity
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-KeC_star(amrex::Real Ce, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real KeC_star(amrex::Real Ce, const ProbParm& prob_parm)
 {
     amrex::Real Xeff_Xbulk = XeffXbulk(prob_parm);
     amrex::Real Xbulk = Ke_Bulk_star(Ce, prob_parm);
@@ -181,23 +174,24 @@ KeC_star(amrex::Real Ce, const ProbParm& prob_parm)
 
 // Electrolyte diffusion coefficient [m2.s-1]. Bulk value, not be used directly
 // in transport equations Ce in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-De_Bulk(amrex::Real Ce, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real De_Bulk(amrex::Real Ce, const ProbParm& prob_parm)
 {
 
-    if (prob_parm.mater_electrolyte == 0) {
+    if (prob_parm.mater_electrolyte == 0)
+    {
         amrex::Real Debulk = 1.34866e-10;
         return Debulk;
-    } else if (prob_parm.mater_electrolyte == 1) {
+    } else if (prob_parm.mater_electrolyte == 1)
+    {
         constexpr amrex::Real a4 = 7.414554029503555e-25;
         constexpr amrex::Real a3 = -1.159860784909586e-20;
         constexpr amrex::Real a2 = 7.492287453960106e-17;
         constexpr amrex::Real a1 = -2.451314899670142e-13;
         constexpr amrex::Real a0 = 3.396397365975209e-10;
-        return amrex::max(
-            (((a4 * Ce + a3) * Ce + a2) * Ce + a1) * Ce + a0,
-            myeps); // [m2.s-1]
-    } else {
+        return amrex::max((((a4 * Ce + a3) * Ce + a2) * Ce + a1) * Ce + a0,
+                          myeps); // [m2.s-1]
+    } else
+    {
         amrex::Abort(
             "Incorrect user-parameter mater_electrolyte in "
             "ChemistryProbParm.H");
@@ -207,8 +201,7 @@ De_Bulk(amrex::Real Ce, const ProbParm& prob_parm)
 
 // Electrolyte diffusion coefficient [m2.s-1]. Actual value to be used in
 // transport equations Ce in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-De_C(amrex::Real Ce, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real De_C(amrex::Real Ce, const ProbParm& prob_parm)
 {
     amrex::Real Xeff_Xbulk = XeffXbulk(prob_parm);
     amrex::Real Xbulk = De_Bulk(Ce, prob_parm);
@@ -218,18 +211,20 @@ De_C(amrex::Real Ce, const ProbParm& prob_parm)
 
 // Transference number [-]
 // Ce in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-t_plus(amrex::Real Ce, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real t_plus(amrex::Real Ce, const ProbParm& prob_parm)
 {
-    if (prob_parm.mater_electrolyte == 0) {
+    if (prob_parm.mater_electrolyte == 0)
+    {
         amrex::Real tplus = 0.462925;
         return tplus;
-    } else if (prob_parm.mater_electrolyte == 1) {
+    } else if (prob_parm.mater_electrolyte == 1)
+    {
         constexpr amrex::Real a2 = -2.266955710225041e-09;
         constexpr amrex::Real a1 = 2.125258249150030e-05;
         constexpr amrex::Real a0 = 0.440686353438825;
         return amrex::max((a2 * Ce + a1) * Ce + a0, myeps);
-    } else {
+    } else
+    {
         amrex::Abort(
             "Incorrect user-parameter mater_electrolyte in "
             "ChemistryProbParm.H");
@@ -239,19 +234,21 @@ t_plus(amrex::Real Ce, const ProbParm& prob_parm)
 
 // Electrolyte activity [-]
 // Ce in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-Activity_el(amrex::Real Ce, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real Activity_el(amrex::Real Ce, const ProbParm& prob_parm)
 {
-    if (prob_parm.mater_electrolyte == 0) {
+    if (prob_parm.mater_electrolyte == 0)
+    {
         amrex::Real Activityel = 2.86877;
         return Activityel;
-    } else if (prob_parm.mater_electrolyte == 1) {
+    } else if (prob_parm.mater_electrolyte == 1)
+    {
         // Valid for temperature = 30 + 273.15 K
         constexpr amrex::Real a2 = 1.598531153290851e-06;
         constexpr amrex::Real a1 = -1.997682922513610e-04;
         constexpr amrex::Real a0 = 0.806611708428853;
         return amrex::max((a2 * Ce + a1) * Ce + a0, myeps);
-    } else {
+    } else
+    {
         amrex::Abort(
             "Incorrect user-parameter mater_electrolyte in "
             "ChemistryProbParm.H");
@@ -268,110 +265,106 @@ Activity_el(amrex::Real Ce, const ProbParm& prob_parm)
 //   and/or high applied current). For other cases, the baseline expression
 //   works. (to test/debug the model, Kd start is not required, except if
 //   testing is for fast charge and/or thick electrodes)
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-K_D(amrex::Real Ce, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real K_D(amrex::Real Ce, const ProbParm& prob_parm)
 {
     // FIXME: hard coding this for now
     // return -0.1;
 
-    const amrex::Real RTF =
-        prob_parm.R_gas_const * prob_parm.T0 / prob_parm.Faraday_const;
-    if (prob_parm.use_KDstar) {
-        return amrex::max(
-            (1.0 - t_plus(Ce, prob_parm)) * (1.0 + Activity_el(Ce, prob_parm)) *
-                2.0 * KeC_star(Ce, prob_parm) * RTF,
-            myeps);
-    } else {
-        return amrex::max(
-            (1.0 - t_plus(Ce, prob_parm)) * (1.0 + Activity_el(Ce, prob_parm)) *
-                2.0 * KeC(Ce, prob_parm) * RTF,
-            myeps);
+    const amrex::Real RTF = prob_parm.R_gas_const * prob_parm.T0 / prob_parm.Faraday_const;
+    if (prob_parm.use_KDstar)
+    {
+        return amrex::max((1.0 - t_plus(Ce, prob_parm)) * (1.0 + Activity_el(Ce, prob_parm)) * 2.0 * KeC_star(Ce, prob_parm) * RTF, myeps);
+    } else
+    {
+        return amrex::max((1.0 - t_plus(Ce, prob_parm)) * (1.0 + Activity_el(Ce, prob_parm)) * 2.0 * KeC(Ce, prob_parm) * RTF, myeps);
     }
 }
 
 // ANODE MATERIAL COEFFICIENTS
 
 // Anode maximum concentration [mol.m-3]
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-Cs_max_anode(const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real Cs_max_anode(const ProbParm& prob_parm)
 {
-    if (prob_parm.mater_anode == 0) {
+    if (prob_parm.mater_anode == 0)
+    {
         const amrex::Real csmax_anode = 28000.0;
         return csmax_anode;
-    } else if (prob_parm.mater_anode == 1) {
+    } else if (prob_parm.mater_anode == 1)
+    {
         const amrex::Real csmax_anode = 28000.0;
         return csmax_anode;
-    } else {
-        amrex::Abort(
-            "Incorrect user-parameter mater_anode in ChemistryProbParm.H");
+    } else
+    {
+        amrex::Abort("Incorrect user-parameter mater_anode in ChemistryProbParm.H");
         return 0;
     }
 }
 
 // Anode conductivity [S.m-1]
 // Cs in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-Ka_bulk(amrex::Real Cs, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real Ka_bulk(amrex::Real Cs, const ProbParm& prob_parm)
 {
-    if (prob_parm.mater_anode == 0) {
+    if (prob_parm.mater_anode == 0)
+    {
         amrex::Real Kabulk = 100;
         return Kabulk;
-    } else if (prob_parm.mater_anode == 1) {
+    } else if (prob_parm.mater_anode == 1)
+    {
         amrex::Real Kabulk = 100;
         return Kabulk;
-    } else {
-        amrex::Abort(
-            "Incorrect user-parameter mater_anode in ChemistryProbParm.H");
+    } else
+    {
+        amrex::Abort("Incorrect user-parameter mater_anode in ChemistryProbParm.H");
         return 0;
     }
 }
 
 // Anode diffusion coefficient [m2.s-1]
 // Cs in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-Da_bulk(amrex::Real Cs, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real Da_bulk(amrex::Real Cs, const ProbParm& prob_parm)
 {
-    if (prob_parm.mater_anode == 0) {
+    if (prob_parm.mater_anode == 0)
+    {
         amrex::Real Dabulk = 3e-14;
         return Dabulk;
-    } else if (prob_parm.mater_anode == 1) {
+    } else if (prob_parm.mater_anode == 1)
+    {
         amrex::Real Dabulk = 3e-14;
         return Dabulk;
-    } else {
-        amrex::Abort(
-            "Incorrect user-parameter mater_anode in ChemistryProbParm.H");
+    } else
+    {
+        amrex::Abort("Incorrect user-parameter mater_anode in ChemistryProbParm.H");
         return 0;
     }
 }
 
 // Anode exchange current density [A.m-2]
 // Cs in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-Io_a(amrex::Real Cs, amrex::Real Ce, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real Io_a(amrex::Real Cs, amrex::Real Ce, const ProbParm& prob_parm)
 {
     amrex::Real x = Cs / Cs_max_anode(prob_parm);
-    if (prob_parm.mater_anode == 0) {
-        amrex::Real ioa =
-            11 * pow(Ce / 1000, 0.5) * pow(x, 0.5) * pow(1 - x, 0.5);
+    if (prob_parm.mater_anode == 0)
+    {
+        amrex::Real ioa = 11 * pow(Ce / 1000, 0.5) * pow(x, 0.5) * pow(1 - x, 0.5);
         return ioa;
-    } else if (prob_parm.mater_anode == 1) {
-        amrex::Real ioa =
-            11 * pow(Ce / 1000, 0.5) * pow(x, 0.5) * pow(1 - x, 0.5);
+    } else if (prob_parm.mater_anode == 1)
+    {
+        amrex::Real ioa = 11 * pow(Ce / 1000, 0.5) * pow(x, 0.5) * pow(1 - x, 0.5);
         return ioa;
-    } else {
-        amrex::Abort(
-            "Incorrect user-parameter mater_anode in ChemistryProbParm.H");
+    } else
+    {
+        amrex::Abort("Incorrect user-parameter mater_anode in ChemistryProbParm.H");
         return 0;
     }
 }
 
 // Anode Open circuit voltage [V]
 // Cs in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-OCP_a(amrex::Real Cs, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real OCP_a(amrex::Real Cs, const ProbParm& prob_parm)
 {
     amrex::Real x = Cs / Cs_max_anode(prob_parm);
-    if (prob_parm.mater_anode == 0) {
+    if (prob_parm.mater_anode == 0)
+    {
         constexpr amrex::Real a7 = -201.8048;
         constexpr amrex::Real a6 = 730.918;
         constexpr amrex::Real a5 = -1074.645;
@@ -380,19 +373,18 @@ OCP_a(amrex::Real Cs, const ProbParm& prob_parm)
         constexpr amrex::Real a2 = 84.66978;
         constexpr amrex::Real a1 = -10.57909;
         constexpr amrex::Real a0 = 0.6848288;
-        amrex::Real OCPa =
-            ((((((a7 * x + a6) * x + a5) * x + a4) * x + a3) * x + a2) * x +
-             a1) *
-                x +
-            a0;
+        amrex::Real OCPa = ((((((a7 * x + a6) * x + a5) * x + a4) * x + a3) * x + a2) * x + a1) * x + a0;
         return OCPa;
-    } else if (prob_parm.mater_anode == 1) {
-        if (x >= 0.98) {
+    } else if (prob_parm.mater_anode == 1)
+    {
+        if (x >= 0.98)
+        {
             constexpr amrex::Real a = (1e-4 - 0.014763) / (1.1 - 0.98);
             constexpr amrex::Real b = 0.014763 - a * 0.98;
             amrex::Real OCPa = a * x + b;
             return OCPa;
-        } else {
+        } else
+        {
             constexpr amrex::Real a1 = -1.059423355572770E-02;
             constexpr amrex::Real a2 = 2.443615203087110E-02;
             constexpr amrex::Real a3 = -1.637520788053810E-02;
@@ -420,12 +412,8 @@ OCP_a(amrex::Real Cs, const ProbParm& prob_parm)
             constexpr amrex::Real c7 = -2.046776012570780E-02;
             constexpr amrex::Real c8 = 3.593817905677970E-02;
 
-            amrex::Real U1 =
-                a1 * tanh((x - b1) / c1) + a2 * tanh((x - b2) / c2) +
-                a3 * tanh((x - b3) / c3) + a4 * tanh((x - b4) / c4) +
-                a5 * tanh((x - b5) / c5) + a6 * tanh((x - b6) / c6) +
-                a7 * tanh((x - b7) / c7) + a8 * tanh((x - b8) / c8) +
-                6.594735004847470e-1;
+            amrex::Real U1 = a1 * tanh((x - b1) / c1) + a2 * tanh((x - b2) / c2) + a3 * tanh((x - b3) / c3) + a4 * tanh((x - b4) / c4) +
+                             a5 * tanh((x - b5) / c5) + a6 * tanh((x - b6) / c6) + a7 * tanh((x - b7) / c7) + a8 * tanh((x - b8) / c8) + 6.594735004847470e-1;
 
             constexpr amrex::Real d0 = -5.037944982759270E+01;
             constexpr amrex::Real d1 = -1.228217254296760E+01;
@@ -437,22 +425,14 @@ OCP_a(amrex::Real Cs, const ProbParm& prob_parm)
             constexpr amrex::Real d7 = +8.252008712749000E+01;
             constexpr amrex::Real d8 = -1.731504647676420E+02;
 
-            amrex::Real U2 =
-                (((((((d8 * x + d7) * x + d6) * x + d5) * x + d4) * x + d3) *
-                      x +
-                  d2) *
-                     x +
-                 d1) *
-                    x +
-                d0;
+            amrex::Real U2 = (((((((d8 * x + d7) * x + d6) * x + d5) * x + d4) * x + d3) * x + d2) * x + d1) * x + d0;
 
-            amrex::Real OCPa =
-                U1 + (U2 - U1) / (1.0 + exp(-1.0e2 * (x - 1.02956203215198)));
+            amrex::Real OCPa = U1 + (U2 - U1) / (1.0 + exp(-1.0e2 * (x - 1.02956203215198)));
             return OCPa;
         }
-    } else {
-        amrex::Abort(
-            "Incorrect user-parameter mater_anode in ChemistryProbParm.H");
+    } else
+    {
+        amrex::Abort("Incorrect user-parameter mater_anode in ChemistryProbParm.H");
         return 0;
     }
 }
@@ -460,52 +440,55 @@ OCP_a(amrex::Real Cs, const ProbParm& prob_parm)
 // CATHODE MATERIAL COEFFICIENTS
 
 // Cathode maximum concentration [mol.m-3]
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-Cs_max_cathode(const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real Cs_max_cathode(const ProbParm& prob_parm)
 {
 
-    if (prob_parm.mater_cathode == 0) {
+    if (prob_parm.mater_cathode == 0)
+    {
         const amrex::Real csmax_cathode = 49600.0;
         return csmax_cathode;
-    } else if (prob_parm.mater_cathode == 1) {
+    } else if (prob_parm.mater_cathode == 1)
+    {
         const amrex::Real csmax_cathode = 49600.0;
         return csmax_cathode;
-    } else {
-        amrex::Abort(
-            "Incorrect user-parameter mater_cathode in ChemistryProbParm.H");
+    } else
+    {
+        amrex::Abort("Incorrect user-parameter mater_cathode in ChemistryProbParm.H");
         return 0;
     }
 }
 
 // Cathode conductivity [S.m-1]
 // Cs in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-Kc_bulk(amrex::Real Cs, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real Kc_bulk(amrex::Real Cs, const ProbParm& prob_parm)
 {
 
-    if (prob_parm.mater_cathode == 0) {
+    if (prob_parm.mater_cathode == 0)
+    {
         amrex::Real Kcbulk = 10;
         return Kcbulk;
-    } else if (prob_parm.mater_cathode == 1) {
+    } else if (prob_parm.mater_cathode == 1)
+    {
         amrex::Real Kcbulk = 10;
         return Kcbulk;
-    } else {
-        amrex::Abort(
-            "Incorrect user-parameter mater_cathode in ChemistryProbParm.H");
+    } else
+    {
+        amrex::Abort("Incorrect user-parameter mater_cathode in ChemistryProbParm.H");
         return 0;
     }
 }
 
 // Cathode diffusion coefficient [m2.s-1]
 // Cs in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-Dc_bulk(amrex::Real Cs, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real Dc_bulk(amrex::Real Cs, const ProbParm& prob_parm)
 {
     amrex::Real x = Cs / Cs_max_cathode(prob_parm);
-    if (prob_parm.mater_cathode == 0) {
+    if (prob_parm.mater_cathode == 0)
+    {
         amrex::Real Dcbulk = 8.39694e-15;
         return Dcbulk;
-    } else if (prob_parm.mater_cathode == 1) {
+    } else if (prob_parm.mater_cathode == 1)
+    {
         constexpr amrex::Real tolerance = 1e-9;
         constexpr amrex::Real x_threshold_1 = -0.10000000000000000555;
         constexpr amrex::Real x_threshold_2 = 0.00000000000000000000;
@@ -518,55 +501,37 @@ Dc_bulk(amrex::Real Cs, const ProbParm& prob_parm)
         constexpr amrex::Real a1_2 = 0.00000000000000000000;
         constexpr amrex::Real a1_1 = 0.00000000000000000000;
         constexpr amrex::Real a1_0 = 0.00000000000000205222;
-        amrex::Real u1 =
-            ((a1_3 * (x - x_threshold_1) + a1_2) * (x - x_threshold_1) + a1_1) *
-                (x - x_threshold_1) +
-            a1_0;
+        amrex::Real u1 = ((a1_3 * (x - x_threshold_1) + a1_2) * (x - x_threshold_1) + a1_1) * (x - x_threshold_1) + a1_0;
 
         constexpr amrex::Real a2_3 = 0.00000000000000000000;
         constexpr amrex::Real a2_2 = 0.00000000000000000000;
         constexpr amrex::Real a2_1 = 0.00000000000000000000;
         constexpr amrex::Real a2_0 = 0.00000000000000205222;
-        amrex::Real u2 =
-            ((a2_3 * (x - x_threshold_2) + a2_2) * (x - x_threshold_2) + a2_1) *
-                (x - x_threshold_2) +
-            a2_0;
+        amrex::Real u2 = ((a2_3 * (x - x_threshold_2) + a2_2) * (x - x_threshold_2) + a2_1) * (x - x_threshold_2) + a2_0;
 
         constexpr amrex::Real a3_3 = -0.00000000000000001127;
         constexpr amrex::Real a3_2 = -0.00000000000000007010;
         constexpr amrex::Real a3_1 = 0.00000000000000000000;
         constexpr amrex::Real a3_0 = 0.00000000000000205222;
-        amrex::Real u3 =
-            ((a3_3 * (x - x_threshold_3) + a3_2) * (x - x_threshold_3) + a3_1) *
-                (x - x_threshold_3) +
-            a3_0;
+        amrex::Real u3 = ((a3_3 * (x - x_threshold_3) + a3_2) * (x - x_threshold_3) + a3_1) * (x - x_threshold_3) + a3_0;
 
         constexpr amrex::Real a4_3 = 0.00000000000000146457;
         constexpr amrex::Real a4_2 = -0.00000000000000272898;
         constexpr amrex::Real a4_1 = -0.00000000000000004510;
         constexpr amrex::Real a4_0 = 0.00000000000000204560;
-        amrex::Real u4 =
-            ((a4_3 * (x - x_threshold_4) + a4_2) * (x - x_threshold_4) + a4_1) *
-                (x - x_threshold_4) +
-            a4_0;
+        amrex::Real u4 = ((a4_3 * (x - x_threshold_4) + a4_2) * (x - x_threshold_4) + a4_1) * (x - x_threshold_4) + a4_0;
 
         constexpr amrex::Real a5_3 = 0.00000000000020947640;
         constexpr amrex::Real a5_2 = -0.00000000000006175755;
         constexpr amrex::Real a5_1 = -0.00000000000000096095;
         constexpr amrex::Real a5_0 = 0.00000000000000193914;
-        amrex::Real u5 =
-            ((a5_3 * (x - x_threshold_5) + a5_2) * (x - x_threshold_5) + a5_1) *
-                (x - x_threshold_5) +
-            a5_0;
+        amrex::Real u5 = ((a5_3 * (x - x_threshold_5) + a5_2) * (x - x_threshold_5) + a5_1) * (x - x_threshold_5) + a5_0;
 
         constexpr amrex::Real a6_3 = -0.00000000000000006031;
         constexpr amrex::Real a6_2 = 0.00000000000000090514;
         constexpr amrex::Real a6_1 = -0.00000000000000052680;
         constexpr amrex::Real a6_0 = 0.00000000000000095246;
-        amrex::Real u6 =
-            ((a6_3 * (x - x_threshold_6) + a6_2) * (x - x_threshold_6) + a6_1) *
-                (x - x_threshold_6) +
-            a6_0;
+        amrex::Real u6 = ((a6_3 * (x - x_threshold_6) + a6_2) * (x - x_threshold_6) + a6_1) * (x - x_threshold_6) + a6_0;
 
         amrex::Real sign1a = signbit(-(x_threshold_2 - x - tolerance));
         amrex::Real sign1b = signbit(-(x - x_threshold_2 + tolerance));
@@ -589,48 +554,37 @@ Dc_bulk(amrex::Real Cs, const ProbParm& prob_parm)
         // amrex::Real validity_6 = (sign5b + amrex::abs(sign5b))/2;
 
         amrex::Real validity_1 = (sign1a + std::abs(sign1a)) / 2;
-        amrex::Real validity_2 = ((sign1b + std::abs(sign1b)) / 2 +
-                                  (sign2a + std::abs(sign2a)) / 2) -
-                                 1;
-        amrex::Real validity_3 = ((sign2b + std::abs(sign2b)) / 2 +
-                                  (sign3a + std::abs(sign3a)) / 2) -
-                                 1;
-        amrex::Real validity_4 = ((sign3b + std::abs(sign3b)) / 2 +
-                                  (sign4a + std::abs(sign4a)) / 2) -
-                                 1;
-        amrex::Real validity_5 = ((sign4b + std::abs(sign4b)) / 2 +
-                                  (sign5a + std::abs(sign5a)) / 2) -
-                                 1;
+        amrex::Real validity_2 = ((sign1b + std::abs(sign1b)) / 2 + (sign2a + std::abs(sign2a)) / 2) - 1;
+        amrex::Real validity_3 = ((sign2b + std::abs(sign2b)) / 2 + (sign3a + std::abs(sign3a)) / 2) - 1;
+        amrex::Real validity_4 = ((sign3b + std::abs(sign3b)) / 2 + (sign4a + std::abs(sign4a)) / 2) - 1;
+        amrex::Real validity_5 = ((sign4b + std::abs(sign4b)) / 2 + (sign5a + std::abs(sign5a)) / 2) - 1;
         amrex::Real validity_6 = (sign5b + std::abs(sign5b)) / 2;
 
-        amrex::Real D0 = validity_1 * u1 + validity_2 * u2 + validity_3 * u3 +
-                         validity_4 * u4 + validity_5 * u5 + validity_6 * u6;
+        amrex::Real D0 = validity_1 * u1 + validity_2 * u2 + validity_3 * u3 + validity_4 * u4 + validity_5 * u5 + validity_6 * u6;
 
         // Radius correction
         constexpr amrex::Real radius_fit = 1.8e-6;           // m
         constexpr amrex::Real radius_cathodeparticle = 5e-6; // m
-        amrex::Real Dcbulk =
-            D0 * 1.5 /
-            sqrt(pow(radius_fit, 2) / pow(radius_cathodeparticle, 2));
+        amrex::Real Dcbulk = D0 * 1.5 / sqrt(pow(radius_fit, 2) / pow(radius_cathodeparticle, 2));
         return Dcbulk;
-    } else {
-        amrex::Abort(
-            "Incorrect user-parameter mater_cathode in ChemistryProbParm.H");
+    } else
+    {
+        amrex::Abort("Incorrect user-parameter mater_cathode in ChemistryProbParm.H");
         return 0;
     }
 }
 
 // Cathode exchange current density [A.m-2]
 // Cs in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-Io_c(amrex::Real Cs, amrex::Real Ce, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real Io_c(amrex::Real Cs, amrex::Real Ce, const ProbParm& prob_parm)
 {
     amrex::Real x = Cs / Cs_max_cathode(prob_parm);
-    if (prob_parm.mater_cathode == 0) {
-        amrex::Real ioc =
-            6 * pow(Ce / 1000, 0.5) * pow(x, 0.5) * pow(1 - x, 0.5);
+    if (prob_parm.mater_cathode == 0)
+    {
+        amrex::Real ioc = 6 * pow(Ce / 1000, 0.5) * pow(x, 0.5) * pow(1 - x, 0.5);
         return ioc;
-    } else if (prob_parm.mater_cathode == 1) {
+    } else if (prob_parm.mater_cathode == 1)
+    {
         constexpr amrex::Real a0 = 0.303490440978371;
         constexpr amrex::Real a1 = 1.271944700013477;
         constexpr amrex::Real a2 = 4.420894220185683e+02;
@@ -642,40 +596,31 @@ Io_c(amrex::Real Cs, amrex::Real Ce, const ProbParm& prob_parm)
         constexpr amrex::Real a8 = 3.347705415406199e+05;
         constexpr amrex::Real a9 = -1.485221335897379e+05;
         constexpr amrex::Real a10 = 2.803425068966447e+04;
-        amrex::Real P =
-            (((((((((a10 * x + a9) * x + a8) * x + a7) * x + a6) * x + a5) * x +
-                a4) *
-                   x +
-               a3) *
-                  x +
-              a2) *
-                 x +
-             a1) *
-                x +
-            a0;
+        amrex::Real P = (((((((((a10 * x + a9) * x + a8) * x + a7) * x + a6) * x + a5) * x + a4) * x + a3) * x + a2) * x + a1) * x + a0;
         amrex::Real ioc = P * sqrt(Ce / prob_parm.ce_atrest);
         return ioc;
-    } else {
-        amrex::Abort(
-            "Incorrect user-parameter mater_cathode in ChemistryProbParm.H");
+    } else
+    {
+        amrex::Abort("Incorrect user-parameter mater_cathode in ChemistryProbParm.H");
         return 0;
     }
 }
 
 // Cathode Open circuit voltage [V]
 // Cs in mol.m-3
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-OCP_c(amrex::Real Cs, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real OCP_c(amrex::Real Cs, const ProbParm& prob_parm)
 {
     amrex::Real x = Cs / Cs_max_cathode(prob_parm);
-    if (prob_parm.mater_cathode == 0) {
+    if (prob_parm.mater_cathode == 0)
+    {
         constexpr amrex::Real a3 = -1.3711668;
         constexpr amrex::Real a2 = 3.9033218;
         constexpr amrex::Real a1 = -4.3438781;
         constexpr amrex::Real a0 = 5.3701447;
         amrex::Real OCPc = ((a3 * x + a2) * x + a1) * x + a0;
         return OCPc;
-    } else if (prob_parm.mater_cathode == 1) {
+    } else if (prob_parm.mater_cathode == 1)
+    {
         constexpr amrex::Real a14 = -3.640118e3;
         constexpr amrex::Real a13 = 1.317658e4;
         constexpr amrex::Real a12 = -1.455742e4;
@@ -692,31 +637,15 @@ OCP_c(amrex::Real Cs, const ProbParm& prob_parm)
         constexpr amrex::Real a1 = -4.158277;
         constexpr amrex::Real a0 = 5.314736;
         amrex::Real A =
-            (((((((((((((a14 * x + a13) * x + a12) * x + a11) * x + a10) * x +
-                     a9) *
-                        x +
-                    a8) *
-                       x +
-                   a7) *
-                      x +
-                  a6) *
-                     x +
-                 a5) *
-                    x +
-                a4) *
-                   x +
-               a3) *
-                  x +
-              a2) *
-                 x +
+            (((((((((((((a14 * x + a13) * x + a12) * x + a11) * x + a10) * x + a9) * x + a8) * x + a7) * x + a6) * x + a5) * x + a4) * x + a3) * x + a2) * x +
              a1) *
                 x +
             a0;
         amrex::Real OCPc = A - 5.573191e-4 * exp(6.560241 * pow(x, 41.482093));
         return OCPc;
-    } else {
-        amrex::Abort(
-            "Incorrect user-parameter mater_cathode in ChemistryProbParm.H");
+    } else
+    {
+        amrex::Abort("Incorrect user-parameter mater_cathode in ChemistryProbParm.H");
         return 0;
     }
 }
@@ -735,43 +664,37 @@ OCP_c(amrex::Real Cs, const ProbParm& prob_parm)
     }
 */
 
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real intercalation_reaction_anode(
-    amrex::Real Ca,
-    amrex::Real phi_a,
-    amrex::Real Ce,
-    amrex::Real phi_e,
-    const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+intercalation_reaction_anode(amrex::Real Ca, amrex::Real phi_a, amrex::Real Ce, amrex::Real phi_e, const ProbParm& prob_parm)
 {
     const amrex::Real ioa = Io_a(Ca, Ce, prob_parm);
     const amrex::Real OCPa = OCP_a(Ca, prob_parm);
     const amrex::Real eta = phi_a - phi_e - OCPa;
-    const amrex::Real FRT =
-        prob_parm.Faraday_const / (prob_parm.R_gas_const * prob_parm.T0);
+    const amrex::Real FRT = prob_parm.Faraday_const / (prob_parm.R_gas_const * prob_parm.T0);
     bool use_sinh = false;
-    if (use_sinh) {
+    if (use_sinh)
+    {
         return 2.0 * ioa * std::sinh(0.5 * FRT * eta); // FIXME: gpu safe?
-    } else {
+    } else
+    {
         amrex::Real A = 0.5 * FRT * eta;
         return ioa * (exp(A) - exp(-A)); // equivalent expression
     }
 }
 
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real intercalation_reaction_cathode(
-    amrex::Real Cc,
-    amrex::Real phi_c,
-    amrex::Real Ce,
-    amrex::Real phi_e,
-    const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+intercalation_reaction_cathode(amrex::Real Cc, amrex::Real phi_c, amrex::Real Ce, amrex::Real phi_e, const ProbParm& prob_parm)
 {
     const amrex::Real ioc = Io_c(Cc, Ce, prob_parm);
     const amrex::Real OCPc = OCP_c(Cc, prob_parm);
     const amrex::Real eta = phi_c - phi_e - OCPc;
-    const amrex::Real FRT =
-        prob_parm.Faraday_const / (prob_parm.R_gas_const * prob_parm.T0);
+    const amrex::Real FRT = prob_parm.Faraday_const / (prob_parm.R_gas_const * prob_parm.T0);
     bool use_sinh = false;
-    if (use_sinh) {
+    if (use_sinh)
+    {
         return 2.0 * ioc * std::sinh(0.5 * FRT * eta); // FIXME: gpu safe?
-    } else {
+    } else
+    {
         amrex::Real A = 0.5 * FRT * eta;
         return ioc * (exp(A) - exp(-A)); // equivalent expression
     }
@@ -783,39 +706,28 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real intercalation_reaction_cathode(
 // Consists in solving the set of equation for an equivalent 0D model (i.e., in
 // each domain potential and concentration are uniform)
 
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real get_phie_initial_from_anode(
-    amrex::Real j, amrex::Real phi_s, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real get_phie_initial_from_anode(amrex::Real j, amrex::Real phi_s, const ProbParm& prob_parm)
 {
     const amrex::Real Ca = prob_parm.soc_anode_t0 * Cs_max_anode(prob_parm);
     const amrex::Real io = Io_a(Ca, prob_parm.ce_atrest, prob_parm);
     const amrex::Real ocp = OCP_a(Ca, prob_parm);
     amrex::Real A = asinh(j / (2 * io)); // asinh safe?
-    amrex::Real eta = A * prob_parm.R_gas_const * prob_parm.T0 /
-                      (0.5 * prob_parm.Faraday_const);
+    amrex::Real eta = A * prob_parm.R_gas_const * prob_parm.T0 / (0.5 * prob_parm.Faraday_const);
     return phi_s - eta - ocp;
 }
 
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-get_phic_initial_from_electrolyte(
-    amrex::Real j, amrex::Real phi_e, const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real get_phic_initial_from_electrolyte(amrex::Real j, amrex::Real phi_e, const ProbParm& prob_parm)
 {
     const amrex::Real Cc = prob_parm.soc_cathode_t0 * Cs_max_cathode(prob_parm);
     const amrex::Real io = Io_c(Cc, prob_parm.ce_atrest, prob_parm);
     const amrex::Real ocp = OCP_c(Cc, prob_parm);
     amrex::Real A = asinh(j / (2 * io)); // asinh safe?
-    amrex::Real eta = A * prob_parm.R_gas_const * prob_parm.T0 /
-                      (0.5 * prob_parm.Faraday_const);
+    amrex::Real eta = A * prob_parm.R_gas_const * prob_parm.T0 / (0.5 * prob_parm.Faraday_const);
     return eta + phi_e + ocp;
 }
 
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real ic_reaction(
-    const int i,
-    const int j,
-    const int k,
-    const int dir,
-    const amrex::Real normal,
-    amrex::Array4<amrex::Real> const& phi,
-    const ProbParm& prob_parm)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+ic_reaction(const int i, const int j, const int k, const int dir, const amrex::Real normal, amrex::Array4<amrex::Real> const& phi, const ProbParm& prob_parm)
 {
 
     // components
@@ -830,7 +742,8 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real ic_reaction(
     int kleft = k;
     int kright = k;
 
-    switch (dir) {
+    switch (dir)
+    {
     case 0:
         cm1 = level_set_to_component(i - 1, j, k, phi);
         cp1 = level_set_to_component(i + 1, j, k, phi);
@@ -856,13 +769,15 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real ic_reaction(
 
     int cl, cr;
 
-    if (normal > 0.0) {
+    if (normal > 0.0)
+    {
         cl = c0;
         cr = cp1;
         ileft = i;
         jleft = j;
         kleft = k;
-    } else {
+    } else
+    {
         cl = cm1;
         cr = c0;
         iright = i;
@@ -872,34 +787,34 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real ic_reaction(
 
     amrex::Real reaction = 0.0;
 
-    if (cl == cathode && cr == electrolyte) {
+    if (cl == cathode && cr == electrolyte)
+    {
         const amrex::Real Cc = phi(ileft, jleft, kleft, CO_ID);
         const amrex::Real Pc = phi(ileft, jleft, kleft, PO_ID);
         const amrex::Real Ce = phi(iright, jright, kright, CO_ID);
         const amrex::Real Pe = phi(iright, jright, kright, PO_ID);
-        reaction =
-            normal * intercalation_reaction_cathode(Cc, Pc, Ce, Pe, prob_parm);
-    } else if (cl == electrolyte && cr == cathode) {
+        reaction = normal * intercalation_reaction_cathode(Cc, Pc, Ce, Pe, prob_parm);
+    } else if (cl == electrolyte && cr == cathode)
+    {
         const amrex::Real Ce = phi(ileft, jleft, kleft, CO_ID);
         const amrex::Real Pe = phi(ileft, jleft, kleft, PO_ID);
         const amrex::Real Cc = phi(iright, jright, kright, CO_ID);
         const amrex::Real Pc = phi(iright, jright, kright, PO_ID);
-        reaction =
-            -normal * intercalation_reaction_cathode(Cc, Pc, Ce, Pe, prob_parm);
-    } else if (cl == electrolyte && cr == anode) {
+        reaction = -normal * intercalation_reaction_cathode(Cc, Pc, Ce, Pe, prob_parm);
+    } else if (cl == electrolyte && cr == anode)
+    {
         const amrex::Real Ce = phi(ileft, jleft, kleft, CO_ID);
         const amrex::Real Pe = phi(ileft, jleft, kleft, PO_ID);
         const amrex::Real Ca = phi(iright, jright, kright, CO_ID);
         const amrex::Real Pa = phi(iright, jright, kright, PO_ID);
-        reaction =
-            normal * intercalation_reaction_anode(Ca, Pa, Ce, Pe, prob_parm);
-    } else if (cl == anode && cr == electrolyte) {
+        reaction = normal * intercalation_reaction_anode(Ca, Pa, Ce, Pe, prob_parm);
+    } else if (cl == anode && cr == electrolyte)
+    {
         const amrex::Real Ca = phi(ileft, jleft, kleft, CO_ID);
         const amrex::Real Pa = phi(ileft, jleft, kleft, PO_ID);
         const amrex::Real Ce = phi(iright, jright, kright, CO_ID);
         const amrex::Real Pe = phi(iright, jright, kright, PO_ID);
-        reaction =
-            -normal * intercalation_reaction_anode(Ca, Pa, Ce, Pe, prob_parm);
+        reaction = -normal * intercalation_reaction_anode(Ca, Pa, Ce, Pe, prob_parm);
     }
 
     if (isnan(reaction)) amrex::Abort("NaN in ic reaction");

--- a/test/battery/Chemistry.cpp
+++ b/test/battery/Chemistry.cpp
@@ -17,7 +17,8 @@ int find_id(std::string specname)
 {
     int loc = -1;
     auto it = std::find(specnames.begin(), specnames.end(), specname);
-    if (it != specnames.end()) {
+    if (it != specnames.end())
+    {
         loc = it - specnames.begin();
     }
     return (loc);

--- a/test/battery/ChemistryProbParm.H
+++ b/test/battery/ChemistryProbParm.H
@@ -20,18 +20,15 @@ struct ProbParm
     // --------------
 
     // INITIAL CONDITIONS
-    amrex::Real ce_atrest = 1200; // [mol.m-3]
-    amrex::Real soc_anode_t0 =
-        0.04; // [] Should be equal to anode_soc_min (see Applied loading)
-    amrex::Real soc_cathode_t0 =
-        0.92; // [] Should be equal to cathode_soc_max (see Applied loading)
-    amrex::Real phi_reference =
-        5.0; // [V] Arbitrary value (avoid 0.0 for numerical convergence)
+    amrex::Real ce_atrest = 1200;      // [mol.m-3]
+    amrex::Real soc_anode_t0 = 0.04;   // [] Should be equal to anode_soc_min (see Applied loading)
+    amrex::Real soc_cathode_t0 = 0.92; // [] Should be equal to cathode_soc_max (see Applied loading)
+    amrex::Real phi_reference = 5.0;   // [V] Arbitrary value (avoid 0.0 for numerical convergence)
 
     // APPLIED LOADING
     amrex::Real T0 = 300.0_rt; // temperature Kelvin
-    amrex::Real Crate = 1.0; // [] Typically ranges from 1/20 to 6 (6 and above
-                             // are considered fast-charge)
+    amrex::Real Crate = 1.0;   // [] Typically ranges from 1/20 to 6 (6 and above
+                               // are considered fast-charge)
     // Pratical state of charge range is more a material property (should be in
     // Chemistry.H). Although as it informs the initial state of charge and that
     // I prefer not to hard-code an equality (to let the user free to initialize
@@ -39,8 +36,8 @@ struct ProbParm
     amrex::Real cathode_soc_min = 0.567; // [] All the theoritical state of
                                          // charge range is typically not used
     amrex::Real cathode_soc_max = 0.92;  // []
-    amrex::Real anode_soc_min = 0.04; // [] All the theoritical state of charge
-                                      // range is typically not used
+    amrex::Real anode_soc_min = 0.04;    // [] All the theoritical state of charge
+                                         // range is typically not used
     amrex::Real anode_soc_max = 0.77056; // []
 
     // MATERIAL SELECTION
@@ -66,18 +63,12 @@ struct ProbParm
     // (CBD) for the cathode and the anode domains, and separator solid for the
     // separator domain To run the model without impact of this parameter, set
     // porosity=1.0 Porosiy value: real [0,1], Bruggeman exponent: real >=1.5
-    amrex::Real lowerscale_vf_pore_anode =
-        1.0; // In the anode, each mesh cell has a porosity of
-    amrex::Real lowerscale_vf_pore_separator =
-        0.4; // In the separator, each mesh cell has a porosity of
-    amrex::Real lowerscale_vf_pore_cathode =
-        1.0; // In the cathode, each mesh cell has a porosity of
-    amrex::Real lowerscale_p_pore_anode =
-        3.0; // In the anode, each mesh cell has a Bruggeman coefficient of
-    amrex::Real lowerscale_p_pore_separator =
-        2.4; // In the separator, each mesh cell has a Bruggeman coefficient of
-    amrex::Real lowerscale_p_pore_cathode =
-        3.0; // In the cathode, each mesh cell has a Bruggeman coefficient of
+    amrex::Real lowerscale_vf_pore_anode = 1.0;     // In the anode, each mesh cell has a porosity of
+    amrex::Real lowerscale_vf_pore_separator = 0.4; // In the separator, each mesh cell has a porosity of
+    amrex::Real lowerscale_vf_pore_cathode = 1.0;   // In the cathode, each mesh cell has a porosity of
+    amrex::Real lowerscale_p_pore_anode = 3.0;      // In the anode, each mesh cell has a Bruggeman coefficient of
+    amrex::Real lowerscale_p_pore_separator = 2.4;  // In the separator, each mesh cell has a Bruggeman coefficient of
+    amrex::Real lowerscale_p_pore_cathode = 3.0;    // In the cathode, each mesh cell has a Bruggeman coefficient of
 };
 
 struct GlobalStorage
@@ -103,14 +94,12 @@ struct GlobalStorage
     amrex::Real cathode_cc_SA = 0.0;
 
     // Applied current
-    amrex::Real Applied_current = 0.0;   // [A] Initialization
-    amrex::Real charging = 1;            // 1 Charging, -1 Discharging
-    amrex::Real Faraday_const = 96487.0; // [C.mol-1]
-    amrex::Vector<amrex::Real> Mass_error{
-        0, 0, 0, 0,
-        0, 0, 0}; // time [s] / anode current [mol] / electrolyte current [mol]
-                  // / cathode current [mol] / anode target [mol] / electrolyte
-                  // target [mol] / cathode target [mol]
+    amrex::Real Applied_current = 0.0;                          // [A] Initialization
+    amrex::Real charging = 1;                                   // 1 Charging, -1 Discharging
+    amrex::Real Faraday_const = 96487.0;                        // [C.mol-1]
+    amrex::Vector<amrex::Real> Mass_error{0, 0, 0, 0, 0, 0, 0}; // time [s] / anode current [mol] / electrolyte current [mol]
+                                                                // / cathode current [mol] / anode target [mol] / electrolyte
+                                                                // target [mol] / cathode target [mol]
 };
 
 #endif

--- a/test/battery/DirectionSelector.H
+++ b/test/battery/DirectionSelector.H
@@ -52,18 +52,20 @@ using ZDir = DirectionSelector<2>;
 // For example, if we're using ZDir, return a box covering the x-y plane.
 // The IntVect is used to set the constant index in the parallel direction.
 template <typename IndexSelector>
-AMREX_GPU_HOST_DEVICE amrex::Box
-PerpendicularBox(const amrex::Box& bx, const amrex::IntVect& iv)
+AMREX_GPU_HOST_DEVICE amrex::Box PerpendicularBox(const amrex::Box& bx, const amrex::IntVect& iv)
 {
     amrex::IntVect plane_lo, plane_hi;
 
-    if (std::is_same<IndexSelector, XDir>::value) {
+    if (std::is_same<IndexSelector, XDir>::value)
+    {
         plane_lo = {iv[0], bx.smallEnd(1), bx.smallEnd(2)};
         plane_hi = {iv[0], bx.bigEnd(1), bx.bigEnd(2)};
-    } else if (std::is_same<IndexSelector, YDir>::value) {
+    } else if (std::is_same<IndexSelector, YDir>::value)
+    {
         plane_lo = {bx.smallEnd(0), iv[1], bx.smallEnd(2)};
         plane_hi = {bx.bigEnd(0), iv[1], bx.bigEnd(2)};
-    } else {
+    } else
+    {
         plane_lo = {bx.smallEnd(0), bx.smallEnd(1), iv[2]};
         plane_hi = {bx.bigEnd(0), bx.bigEnd(1), iv[2]};
     }
@@ -78,18 +80,20 @@ PerpendicularBox(const amrex::Box& bx, const amrex::IntVect& iv)
 // The IntVect is used to set the constant indices in the perpendicular
 // direction.
 template <typename IndexSelector>
-AMREX_GPU_HOST_DEVICE amrex::Box
-ParallelBox(const amrex::Box& bx, const amrex::IntVect& iv)
+AMREX_GPU_HOST_DEVICE amrex::Box ParallelBox(const amrex::Box& bx, const amrex::IntVect& iv)
 {
     amrex::IntVect line_lo, line_hi;
 
-    if (std::is_same<IndexSelector, XDir>::value) {
+    if (std::is_same<IndexSelector, XDir>::value)
+    {
         line_lo = {bx.smallEnd(0), iv[1], iv[2]};
         line_hi = {bx.bigEnd(0), iv[1], iv[2]};
-    } else if (std::is_same<IndexSelector, YDir>::value) {
+    } else if (std::is_same<IndexSelector, YDir>::value)
+    {
         line_lo = {iv[0], bx.smallEnd(1), iv[2]};
         line_hi = {iv[0], bx.bigEnd(1), iv[2]};
-    } else {
+    } else
+    {
         line_lo = {iv[0], iv[1], bx.smallEnd(2)};
         line_hi = {iv[0], iv[1], bx.bigEnd(2)};
     }

--- a/test/battery/IntegralUtils.H
+++ b/test/battery/IntegralUtils.H
@@ -10,14 +10,7 @@ namespace electrochem_integral_utils {
 // TODO: incorporate a level mask
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-Real volume_value(
-    int i,
-    int j,
-    int k,
-    int comp,
-    int domain,
-    Array4<Real const> const& phi,
-    GpuArray<Real, AMREX_SPACEDIM> dx)
+Real volume_value(int i, int j, int k, int comp, int domain, Array4<Real const> const& phi, GpuArray<Real, AMREX_SPACEDIM> dx)
 {
 
     Real val = 1.0;
@@ -77,7 +70,8 @@ Real surface_value(
     if (k + 1 > domhi[2]) z_next = -1;
 
     // Check if we are in domain1 and the adjacent cell is domain2 or boundary
-    if ((phi(i, j, k, domain1) > 0)) {
+    if ((phi(i, j, k, domain1) > 0))
+    {
         if (same_domain * x_prev > 0) out += val * dx[1] * dx[2];
         if (same_domain * x_next > 0) out += val * dx[1] * dx[2];
         if (same_domain * y_prev > 0) out += val * dx[0] * dx[2];
@@ -95,15 +89,7 @@ Real surface_value(
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
 Real current_collector_value(
-    int i,
-    int j,
-    int k,
-    int comp,
-    int domain,
-    Array4<Real const> const& phi,
-    const int* domlo,
-    const int* domhi,
-    const GpuArray<Real, AMREX_SPACEDIM>& dx)
+    int i, int j, int k, int comp, int domain, Array4<Real const> const& phi, const int* domlo, const int* domhi, const GpuArray<Real, AMREX_SPACEDIM>& dx)
 {
     // Init some values
     Real val = 1.0;
@@ -113,7 +99,8 @@ Real current_collector_value(
     if (comp > -1) val = phi(i, j, k, comp);
 
     // Check if we are in the right domain and at one of the x extremes
-    if ((phi(i, j, k, domain) > 0)) {
+    if ((phi(i, j, k, domain) > 0))
+    {
         if (i - 1 < domlo[0]) out += val * dx[1] * dx[2];
         if (i + 1 > domhi[0]) out += val * dx[1] * dx[2];
     }
@@ -127,8 +114,7 @@ void echemAMR::init_volumes()
 
     // Volumes
     host_global_storage->anode_volume = VolumeIntegral(-1, A_ID);
-    host_global_storage->ele_sep_volume =
-        VolumeIntegral(-1, E_ID) + VolumeIntegral(-1, S_ID);
+    host_global_storage->ele_sep_volume = VolumeIntegral(-1, E_ID) + VolumeIntegral(-1, S_ID);
     host_global_storage->cathode_volume = VolumeIntegral(-1, C_ID);
 
     // Surface Areas

--- a/test/battery/PostProcessing.H
+++ b/test/battery/PostProcessing.H
@@ -30,8 +30,7 @@ void line_plot(
 
     const amrex::Real xlo = geom[0].ProbLo(axis);
     const amrex::Real xhi = geom[0].ProbHi(axis);
-    const amrex::Real line_dx =
-        (xhi - xlo) / static_cast<amrex::Real>(num_points);
+    const amrex::Real line_dx = (xhi - xlo) / static_cast<amrex::Real>(num_points);
 
     amrex::Vector<amrex::Real> line_volume;
     amrex::Vector<amrex::Real> line_minimum;
@@ -46,17 +45,15 @@ void line_plot(
     line_stddev.resize(num_points * num_comps, 0.0);
 
     amrex::Vector<amrex::Real> line_location(num_points);
-    for (int i = 0; i < num_points; ++i) {
+    for (int i = 0; i < num_points; ++i)
+    {
         line_location[i] = xlo + (i + 0.5) * line_dx;
     }
 
     // use AsyncArray to copy to device
-    amrex::AsyncArray<amrex::Real> lmin(
-        line_minimum.data(), line_minimum.size());
-    amrex::AsyncArray<amrex::Real> lavg(
-        line_average.data(), line_average.size());
-    amrex::AsyncArray<amrex::Real> lmax(
-        line_maximum.data(), line_maximum.size());
+    amrex::AsyncArray<amrex::Real> lmin(line_minimum.data(), line_minimum.size());
+    amrex::AsyncArray<amrex::Real> lavg(line_average.data(), line_average.size());
+    amrex::AsyncArray<amrex::Real> lmax(line_maximum.data(), line_maximum.size());
     amrex::AsyncArray<amrex::Real> lstd(line_stddev.data(), line_stddev.size());
     amrex::AsyncArray<amrex::Real> lvol(line_volume.data(), line_volume.size());
 
@@ -66,14 +63,16 @@ void line_plot(
     amrex::Real* line_std = lstd.data();
     amrex::Real* line_vol = lvol.data();
 
-    for (int lev = 0; lev <= finest_level; ++lev) {
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
 
         // mask covered cells
         amrex::iMultiFab level_mask;
-        if (lev < finest_level) {
-            level_mask = makeFineMask(
-                grids[lev], dmap[lev], grids[lev], amrex::IntVect(2), 1, 0);
-        } else {
+        if (lev < finest_level)
+        {
+            level_mask = makeFineMask(grids[lev], dmap[lev], grids[lev], amrex::IntVect(2), 1, 0);
+        } else
+        {
             level_mask.define(grids[lev], dmap[lev], 1, 0);
             level_mask.setVal(1);
         }
@@ -82,72 +81,50 @@ void line_plot(
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
 
-        for (MFIter mfi(phi_new[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        for (MFIter mfi(phi_new[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
             const Box& bx = mfi.tilebox();
             auto phi_arr = phi_new[lev].const_array(mfi);
             auto mask_arr = level_mask.const_array(mfi);
 
-            amrex::Box pbx =
-                PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
+            amrex::Box pbx = PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
 
             amrex::ParallelFor(
-                amrex::Gpu::KernelInfo().setReduction(true), pbx,
-                [=] AMREX_GPU_DEVICE(
-                    int p_i, int p_j, int p_k,
-                    amrex::Gpu::Handler const& handler) noexcept {
+                amrex::Gpu::KernelInfo().setReduction(true), pbx, [=] AMREX_GPU_DEVICE(int p_i, int p_j, int p_k, amrex::Gpu::Handler const& handler) noexcept {
                     // parallel box
-                    amrex::Box lbx = ParallelBox<IndexSelector>(
-                        bx, amrex::IntVect{p_i, p_j, p_k});
+                    amrex::Box lbx = ParallelBox<IndexSelector>(bx, amrex::IntVect{p_i, p_j, p_k});
 
-                    for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {
-                        for (int j = lbx.smallEnd(1); j <= lbx.bigEnd(1); ++j) {
-                            for (int i = lbx.smallEnd(0); i <= lbx.bigEnd(0);
-                                 ++i) {
+                    for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k)
+                    {
+                        for (int j = lbx.smallEnd(1); j <= lbx.bigEnd(1); ++j)
+                        {
+                            for (int i = lbx.smallEnd(0); i <= lbx.bigEnd(0); ++i)
+                            {
 
-                                if (mask_arr(i, j, k) == 1) {
+                                if (mask_arr(i, j, k) == 1)
+                                {
 
                                     // cell coordinates
-                                    const amrex::Real cell_xlo =
-                                        xlo +
-                                        idxOp(i, j, k) *
-                                            geom[lev].CellSizeArray()[axis];
-                                    const amrex::Real cell_xhi =
-                                        cell_xlo +
-                                        geom[lev].CellSizeArray()[axis];
-                                    const amrex::Real dy =
-                                        geom[lev].CellSizeArray()[idxOp.odir1];
-                                    const amrex::Real dz =
-                                        geom[lev].CellSizeArray()[idxOp.odir2];
+                                    const amrex::Real cell_xlo = xlo + idxOp(i, j, k) * geom[lev].CellSizeArray()[axis];
+                                    const amrex::Real cell_xhi = cell_xlo + geom[lev].CellSizeArray()[axis];
+                                    const amrex::Real dy = geom[lev].CellSizeArray()[idxOp.odir1];
+                                    const amrex::Real dz = geom[lev].CellSizeArray()[idxOp.odir2];
 
                                     // line indices
-                                    const int line_ind_lo = amrex::min(
-                                        amrex::max(
-                                            static_cast<int>(
-                                                (cell_xlo - xlo) / line_dx),
-                                            0),
-                                        num_points - 1);
-                                    const int line_ind_hi = amrex::min(
-                                        amrex::max(
-                                            static_cast<int>(
-                                                (cell_xhi - xlo) / line_dx),
-                                            0),
-                                        num_points - 1);
+                                    const int line_ind_lo = amrex::min(amrex::max(static_cast<int>((cell_xlo - xlo) / line_dx), 0), num_points - 1);
+                                    const int line_ind_hi = amrex::min(amrex::max(static_cast<int>((cell_xhi - xlo) / line_dx), 0), num_points - 1);
 
                                     AMREX_ALWAYS_ASSERT(line_ind_lo >= 0);
                                     AMREX_ALWAYS_ASSERT(line_ind_hi >= 0);
-                                    AMREX_ALWAYS_ASSERT(
-                                        line_ind_lo < num_points);
-                                    AMREX_ALWAYS_ASSERT(
-                                        line_ind_hi < num_points);
+                                    AMREX_ALWAYS_ASSERT(line_ind_lo < num_points);
+                                    AMREX_ALWAYS_ASSERT(line_ind_hi < num_points);
 
-                                    for (int ind = line_ind_lo;
-                                         ind <= line_ind_hi; ++ind) {
+                                    for (int ind = line_ind_lo; ind <= line_ind_hi; ++ind)
+                                    {
 
                                         // line coordinates
-                                        const amrex::Real line_xlo =
-                                            xlo + ind * line_dx;
-                                        const amrex::Real line_xhi =
-                                            line_xlo + line_dx;
+                                        const amrex::Real line_xlo = xlo + ind * line_dx;
+                                        const amrex::Real line_xhi = line_xlo + line_dx;
 
                                         amrex::Real dx;
 
@@ -158,37 +135,21 @@ void line_plot(
                                         else
                                             dx = line_dx;
 
-                                        dx = amrex::min(
-                                            dx,
-                                            geom[lev].CellSizeArray()[axis]);
+                                        dx = amrex::min(dx, geom[lev].CellSizeArray()[axis]);
 
-                                        for (int n = 0; n < num_comps; ++n) {
+                                        for (int n = 0; n < num_comps; ++n)
+                                        {
 
-                                            const amrex::Real field =
-                                                phi_arr(i, j, k, index_in);
-                                            const amrex::Real lvlset =
-                                                amrex::max(
-                                                    phi_arr(i, j, k, n + 1),
-                                                    0.0);
-                                            const amrex::Real vol =
-                                                dx * dy * dz;
+                                            const amrex::Real field = phi_arr(i, j, k, index_in);
+                                            const amrex::Real lvlset = amrex::max(phi_arr(i, j, k, n + 1), 0.0);
+                                            const amrex::Real vol = dx * dy * dz;
 
                                             // min is annoying can't use level
                                             // set here
-                                            if (lvlset > 0.0)
-                                                amrex::Gpu::deviceReduceMin(
-                                                    &line_min
-                                                        [num_comps * ind + n],
-                                                    field, handler);
-                                            amrex::Gpu::deviceReduceSum(
-                                                &line_avg[num_comps * ind + n],
-                                                field * lvlset * vol, handler);
-                                            amrex::Gpu::deviceReduceMax(
-                                                &line_max[num_comps * ind + n],
-                                                field * lvlset, handler);
-                                            amrex::Gpu::deviceReduceSum(
-                                                &line_vol[num_comps * ind + n],
-                                                vol * lvlset, handler);
+                                            if (lvlset > 0.0) amrex::Gpu::deviceReduceMin(&line_min[num_comps * ind + n], field, handler);
+                                            amrex::Gpu::deviceReduceSum(&line_avg[num_comps * ind + n], field * lvlset * vol, handler);
+                                            amrex::Gpu::deviceReduceMax(&line_max[num_comps * ind + n], field * lvlset, handler);
+                                            amrex::Gpu::deviceReduceSum(&line_vol[num_comps * ind + n], vol * lvlset, handler);
 
                                         } // component loop
                                     }     // line loop
@@ -205,34 +166,28 @@ void line_plot(
     lmax.copyToHost(line_maximum.data(), line_maximum.size());
     lvol.copyToHost(line_volume.data(), line_volume.size());
 
-    amrex::ParallelDescriptor::ReduceRealMin(
-        line_minimum.data(), line_minimum.size(),
-        ParallelDescriptor::IOProcessorNumber());
-    amrex::ParallelDescriptor::ReduceRealSum(
-        line_average.data(), line_average.size());
-    amrex::ParallelDescriptor::ReduceRealMax(
-        line_maximum.data(), line_maximum.size(),
-        ParallelDescriptor::IOProcessorNumber());
-    amrex::ParallelDescriptor::ReduceRealSum(
-        line_volume.data(), line_volume.size());
+    amrex::ParallelDescriptor::ReduceRealMin(line_minimum.data(), line_minimum.size(), ParallelDescriptor::IOProcessorNumber());
+    amrex::ParallelDescriptor::ReduceRealSum(line_average.data(), line_average.size());
+    amrex::ParallelDescriptor::ReduceRealMax(line_maximum.data(), line_maximum.size(), ParallelDescriptor::IOProcessorNumber());
+    amrex::ParallelDescriptor::ReduceRealSum(line_volume.data(), line_volume.size());
 
     // just make new ones until we figure out how to copytodevice...
-    amrex::AsyncArray<amrex::Real> lavg2(
-        line_average.data(), line_average.size());
-    amrex::AsyncArray<amrex::Real> lvol2(
-        line_volume.data(), line_volume.size());
+    amrex::AsyncArray<amrex::Real> lavg2(line_average.data(), line_average.size());
+    amrex::AsyncArray<amrex::Real> lvol2(line_volume.data(), line_volume.size());
     line_avg = lavg2.data();
     line_vol = lvol2.data();
 
     // FIXME: lots of code duplication here...
-    for (int lev = 0; lev <= finest_level; ++lev) {
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
 
         // mask covered cells
         amrex::iMultiFab level_mask;
-        if (lev < finest_level) {
-            level_mask = makeFineMask(
-                grids[lev], dmap[lev], grids[lev], amrex::IntVect(2), 1, 0);
-        } else {
+        if (lev < finest_level)
+        {
+            level_mask = makeFineMask(grids[lev], dmap[lev], grids[lev], amrex::IntVect(2), 1, 0);
+        } else
+        {
             level_mask.define(grids[lev], dmap[lev], 1, 0);
             level_mask.setVal(1);
         }
@@ -241,64 +196,44 @@ void line_plot(
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
 
-        for (MFIter mfi(phi_new[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        for (MFIter mfi(phi_new[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
             const Box& bx = mfi.tilebox();
             auto phi_arr = phi_new[lev].const_array(mfi);
             auto mask_arr = level_mask.const_array(mfi);
 
-            amrex::Box pbx =
-                PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
+            amrex::Box pbx = PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
 
             amrex::ParallelFor(
-                amrex::Gpu::KernelInfo().setReduction(true), pbx,
-                [=] AMREX_GPU_DEVICE(
-                    int p_i, int p_j, int p_k,
-                    amrex::Gpu::Handler const& handler) noexcept {
-                    amrex::Box lbx = ParallelBox<IndexSelector>(
-                        bx, amrex::IntVect{p_i, p_j, p_k});
+                amrex::Gpu::KernelInfo().setReduction(true), pbx, [=] AMREX_GPU_DEVICE(int p_i, int p_j, int p_k, amrex::Gpu::Handler const& handler) noexcept {
+                    amrex::Box lbx = ParallelBox<IndexSelector>(bx, amrex::IntVect{p_i, p_j, p_k});
 
-                    for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {
-                        for (int j = lbx.smallEnd(1); j <= lbx.bigEnd(1); ++j) {
-                            for (int i = lbx.smallEnd(0); i <= lbx.bigEnd(0);
-                                 ++i) {
+                    for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k)
+                    {
+                        for (int j = lbx.smallEnd(1); j <= lbx.bigEnd(1); ++j)
+                        {
+                            for (int i = lbx.smallEnd(0); i <= lbx.bigEnd(0); ++i)
+                            {
 
-                                if (mask_arr(i, j, k) == 1) {
+                                if (mask_arr(i, j, k) == 1)
+                                {
 
                                     // cell coordinates
-                                    const amrex::Real cell_xlo =
-                                        xlo +
-                                        idxOp(i, j, k) *
-                                            geom[lev].CellSizeArray()[axis];
-                                    const amrex::Real cell_xhi =
-                                        cell_xlo +
-                                        geom[lev].CellSizeArray()[axis];
-                                    const amrex::Real dy =
-                                        geom[lev].CellSizeArray()[idxOp.odir1];
-                                    const amrex::Real dz =
-                                        geom[lev].CellSizeArray()[idxOp.odir2];
+                                    const amrex::Real cell_xlo = xlo + idxOp(i, j, k) * geom[lev].CellSizeArray()[axis];
+                                    const amrex::Real cell_xhi = cell_xlo + geom[lev].CellSizeArray()[axis];
+                                    const amrex::Real dy = geom[lev].CellSizeArray()[idxOp.odir1];
+                                    const amrex::Real dz = geom[lev].CellSizeArray()[idxOp.odir2];
 
                                     // line indices
-                                    const int line_ind_lo = amrex::min(
-                                        amrex::max(
-                                            static_cast<int>(
-                                                (cell_xlo - xlo) / line_dx),
-                                            0),
-                                        num_points - 1);
-                                    const int line_ind_hi = amrex::min(
-                                        amrex::max(
-                                            static_cast<int>(
-                                                (cell_xhi - xlo) / line_dx),
-                                            0),
-                                        num_points - 1);
+                                    const int line_ind_lo = amrex::min(amrex::max(static_cast<int>((cell_xlo - xlo) / line_dx), 0), num_points - 1);
+                                    const int line_ind_hi = amrex::min(amrex::max(static_cast<int>((cell_xhi - xlo) / line_dx), 0), num_points - 1);
 
-                                    for (int ind = line_ind_lo;
-                                         ind <= line_ind_hi; ++ind) {
+                                    for (int ind = line_ind_lo; ind <= line_ind_hi; ++ind)
+                                    {
 
                                         // line coordinates
-                                        const amrex::Real line_xlo =
-                                            xlo + ind * line_dx;
-                                        const amrex::Real line_xhi =
-                                            line_xlo + line_dx;
+                                        const amrex::Real line_xlo = xlo + ind * line_dx;
+                                        const amrex::Real line_xhi = line_xlo + line_dx;
 
                                         amrex::Real dx;
 
@@ -309,30 +244,18 @@ void line_plot(
                                         else
                                             dx = line_dx;
 
-                                        dx = amrex::min(
-                                            dx,
-                                            geom[lev].CellSizeArray()[axis]);
+                                        dx = amrex::min(dx, geom[lev].CellSizeArray()[axis]);
 
-                                        for (int n = 0; n < num_comps; ++n) {
-                                            const amrex::Real field =
-                                                phi_arr(i, j, k, index_in);
+                                        for (int n = 0; n < num_comps; ++n)
+                                        {
+                                            const amrex::Real field = phi_arr(i, j, k, index_in);
                                             // this assumes level sets are
                                             // stacked after concentration
-                                            const amrex::Real lvlset =
-                                                amrex::max(
-                                                    phi_arr(i, j, k, n + 1),
-                                                    0.0);
-                                            const amrex::Real vol =
-                                                dx * dy * dz;
-                                            const amrex::Real mean =
-                                                line_avg[num_comps * ind + n] /
-                                                line_vol[num_comps * ind + n];
-                                            const amrex::Real stddev =
-                                                std::pow(field - mean, 2.0) *
-                                                lvlset * vol;
-                                            amrex::Gpu::deviceReduceSum(
-                                                &line_std[num_comps * ind + n],
-                                                stddev, handler);
+                                            const amrex::Real lvlset = amrex::max(phi_arr(i, j, k, n + 1), 0.0);
+                                            const amrex::Real vol = dx * dy * dz;
+                                            const amrex::Real mean = line_avg[num_comps * ind + n] / line_vol[num_comps * ind + n];
+                                            const amrex::Real stddev = std::pow(field - mean, 2.0) * lvlset * vol;
+                                            amrex::Gpu::deviceReduceSum(&line_std[num_comps * ind + n], stddev, handler);
                                         } // component loop
                                     }     // line loop
                                 }         // mask if statement
@@ -344,12 +267,11 @@ void line_plot(
     }                                     // level loop
 
     lstd.copyToHost(line_stddev.data(), line_stddev.size());
-    amrex::ParallelDescriptor::ReduceRealSum(
-        line_stddev.data(), line_stddev.size(),
-        ParallelDescriptor::IOProcessorNumber());
+    amrex::ParallelDescriptor::ReduceRealSum(line_stddev.data(), line_stddev.size(), ParallelDescriptor::IOProcessorNumber());
 
     // only IO Processor outputs file
-    if (amrex::ParallelDescriptor::IOProcessor()) {
+    if (amrex::ParallelDescriptor::IOProcessor())
+    {
         const int num_files = 4;
 
         AMREX_ALWAYS_ASSERT(num_files == num_comps);
@@ -362,38 +284,32 @@ void line_plot(
         filename[2] = "electrolyte_" + filename_type + ".csv";
         filename[3] = "separator_" + filename_type + ".csv";
 
-        for (int f = 0; f < num_files; ++f) {
-            if (timestep == 0) {
+        for (int f = 0; f < num_files; ++f)
+        {
+            if (timestep == 0)
+            {
                 outfile[f].open(filename[f].c_str(), std::ios_base::out);
                 outfile[f] << "Time_step    Time[s]    Position[m]    Min    "
                               "Mean    Max    Std"
                            << std::endl;
-            } else {
-                outfile[f].open(
-                    filename[f].c_str(),
-                    std::ios_base::out | std::ios_base::app);
+            } else
+            {
+                outfile[f].open(filename[f].c_str(), std::ios_base::out | std::ios_base::app);
             }
 
             outfile[f].precision(16);
 
-            for (int i = 0; i < num_points; ++i) {
-                outfile[f] << timestep << ' ' << std::scientific << time << ' '
-                           << line_location[i] << ' '
-                           << line_minimum[num_comps * i + f] << ' '
-                           << line_average[num_comps * i + f] /
-                                  line_volume[num_comps * i + f]
-                           << ' ' << line_maximum[num_comps * i + f] << ' '
-                           << std::sqrt(
-                                  line_stddev[num_comps * i + f] /
-                                  line_volume[num_comps * i + f])
-                           << std::endl;
+            for (int i = 0; i < num_points; ++i)
+            {
+                outfile[f] << timestep << ' ' << std::scientific << time << ' ' << line_location[i] << ' ' << line_minimum[num_comps * i + f] << ' '
+                           << line_average[num_comps * i + f] / line_volume[num_comps * i + f] << ' ' << line_maximum[num_comps * i + f] << ' '
+                           << std::sqrt(line_stddev[num_comps * i + f] / line_volume[num_comps * i + f]) << std::endl;
             }
         }
     }
 }
 
-void echemAMR::postprocess(
-    Real time, int timestep, Real dt, GlobalStorage* globalstorage)
+void echemAMR::postprocess(Real time, int timestep, Real dt, GlobalStorage* globalstorage)
 // void echemAMR::postprocess(Real time, int timestep, Real dt, Real
 // Applied_current, Real Fday, Real charging, Vector<amrex::Real> Mass_error)
 {
@@ -403,25 +319,19 @@ void echemAMR::postprocess(
     Real cathode_volume = VolumeIntegral(-1, C_ID);
     Real electrolyte_volume = VolumeIntegral(-1, E_ID);
     Real separator_volume = VolumeIntegral(-1, S_ID);
-    Real total_volume =
-        anode_volume + cathode_volume + electrolyte_volume + separator_volume;
+    Real total_volume = anode_volume + cathode_volume + electrolyte_volume + separator_volume;
 
     // Calculate mol per domain (current value)
     Real anode_current_mol = VolumeIntegral(CO_ID, A_ID);
     Real cathode_current_mol = VolumeIntegral(CO_ID, C_ID);
     Real electrolyte_current_mol = VolumeIntegral(CO_ID, E_ID);
     Real separator_current_mol = VolumeIntegral(CO_ID, S_ID);
-    Real total_current_mol = anode_current_mol + cathode_current_mol +
-                             electrolyte_current_mol + separator_current_mol;
+    Real total_current_mol = anode_current_mol + cathode_current_mol + electrolyte_current_mol + separator_current_mol;
 
     // Expected mol per domain (target value)
-    Real anode_target_dmol = globalstorage->charging *
-                             globalstorage->Applied_current * dt /
-                             globalstorage->Faraday_const; // [mol]
-    Real cathode_target_dmol = globalstorage->charging *
-                               globalstorage->Applied_current * dt /
-                               globalstorage->Faraday_const; // [mol]
-    Real electrolyte_target_dmol = 0;                        // [mol]
+    Real anode_target_dmol = globalstorage->charging * globalstorage->Applied_current * dt / globalstorage->Faraday_const;   // [mol]
+    Real cathode_target_dmol = globalstorage->charging * globalstorage->Applied_current * dt / globalstorage->Faraday_const; // [mol]
+    Real electrolyte_target_dmol = 0;                                                                                        // [mol]
     // Real anode_target_dSOC = dt/3600 * Crate; // [] Alternative method, FYI
     // Real anode_target_dC = anode_target_dSOC * Csmax; // [mol.m-3]
     // Real anode_target_dmol = anode_target_dC * anode_volume; // [mol]
@@ -431,19 +341,17 @@ void echemAMR::postprocess(
     // Update mass error array
     Real anode_target_mol, electrolyte_target_mol,
         cathode_target_mol; // Initialization
-    if (timestep == 0) {
+    if (timestep == 0)
+    {
         anode_target_mol = anode_current_mol;             // [mol]
         electrolyte_target_mol = electrolyte_current_mol; // [mol]
         cathode_target_mol = cathode_current_mol;         // [mol]
 
-    } else {
-        anode_target_mol = globalstorage->Mass_error[4] +
-                           anode_target_dmol; // [mol] Theortical value
-        electrolyte_target_mol =
-            globalstorage->Mass_error[5] +
-            electrolyte_target_dmol; // [mol] Theortical value
-        cathode_target_mol = globalstorage->Mass_error[6] +
-                             cathode_target_dmol; // [mol] Theortical value
+    } else
+    {
+        anode_target_mol = globalstorage->Mass_error[4] + anode_target_dmol;             // [mol] Theortical value
+        electrolyte_target_mol = globalstorage->Mass_error[5] + electrolyte_target_dmol; // [mol] Theortical value
+        cathode_target_mol = globalstorage->Mass_error[6] + cathode_target_dmol;         // [mol] Theortical value
     }
 
     // Overwritte
@@ -458,68 +366,42 @@ void echemAMR::postprocess(
     // PRINT STATMENT
     amrex::Print() << std::endl;
 
-    if (timestep == 0) { // Print static information
+    if (timestep == 0)
+    { // Print static information
         amrex::Print() << " VOLUMES:" << std::endl;
-        amrex::Print() << "    Anode Volume:       " << anode_volume << " m3"
-                       << std::endl;
-        amrex::Print() << "    Cathode Volume:     " << cathode_volume << " m3"
-                       << std::endl;
-        amrex::Print() << "    Electrolyte Volume: " << electrolyte_volume
-                       << " m3" << std::endl;
-        amrex::Print() << "    Separator Volume:   " << separator_volume
-                       << " m3" << std::endl;
-        amrex::Print() << "    Total Volume:       " << total_volume << " m3"
-                       << std::endl;
+        amrex::Print() << "    Anode Volume:       " << anode_volume << " m3" << std::endl;
+        amrex::Print() << "    Cathode Volume:     " << cathode_volume << " m3" << std::endl;
+        amrex::Print() << "    Electrolyte Volume: " << electrolyte_volume << " m3" << std::endl;
+        amrex::Print() << "    Separator Volume:   " << separator_volume << " m3" << std::endl;
+        amrex::Print() << "    Total Volume:       " << total_volume << " m3" << std::endl;
         amrex::Print() << std::endl;
     }
 
     amrex::Print() << std::endl;
     amrex::Print() << "----------------------" << std::endl;
-    amrex::Print() << "ITERATION NO: " << timestep << ", (dis)charging time "
-                   << time << " s " << std::endl;
+    amrex::Print() << "ITERATION NO: " << timestep << ", (dis)charging time " << time << " s " << std::endl;
     amrex::Print() << "----------------------" << std::endl;
     amrex::Print() << std::endl;
 
     amrex::Print() << "APPLIED LOADING:" << std::endl;
-    amrex::Print() << "    Applied_current " << globalstorage->Applied_current
-                   << " A"
+    amrex::Print() << "    Applied_current " << globalstorage->Applied_current << " A"
                    << " for duration " << dt << " s" << std::endl;
     amrex::Print() << std::endl;
 
     amrex::Print() << "MOL AND CONCENTRATIONS:       " << std::endl;
-    amrex::Print() << "    Anode:       " << anode_current_mol << " mol / "
-                   << anode_current_mol / anode_volume << " mol.m-3"
-                   << std::endl;
-    amrex::Print() << "    Cathode:     " << cathode_current_mol << " mol / "
-                   << cathode_current_mol / cathode_volume << " mol.m-3"
-                   << std::endl;
-    amrex::Print() << "    Electrolyte: " << electrolyte_current_mol
-                   << " mol / " << electrolyte_current_mol / electrolyte_volume
-                   << " mol.m-3" << std::endl;
-    amrex::Print() << "    Separator:   " << separator_current_mol << " mol / "
-                   << separator_current_mol / separator_volume << " mol.m-3"
-                   << std::endl;
+    amrex::Print() << "    Anode:       " << anode_current_mol << " mol / " << anode_current_mol / anode_volume << " mol.m-3" << std::endl;
+    amrex::Print() << "    Cathode:     " << cathode_current_mol << " mol / " << cathode_current_mol / cathode_volume << " mol.m-3" << std::endl;
+    amrex::Print() << "    Electrolyte: " << electrolyte_current_mol << " mol / " << electrolyte_current_mol / electrolyte_volume << " mol.m-3" << std::endl;
+    amrex::Print() << "    Separator:   " << separator_current_mol << " mol / " << separator_current_mol / separator_volume << " mol.m-3" << std::endl;
     amrex::Print() << std::endl;
 
     amrex::Print() << "MASS ERROR:" << std::endl;
-    amrex::Print() << "    Anode      : current = " << anode_current_mol
-                   << " mol , target = " << anode_target_mol
-                   << " mol , error = "
-                   << 100 * (anode_target_mol - anode_current_mol) /
-                          anode_target_mol
-                   << " % " << std::endl;
-    amrex::Print() << "    Cathode    : current = " << cathode_current_mol
-                   << " mol , target = " << cathode_target_mol
-                   << " mol , error = "
-                   << 100 * (cathode_target_mol - cathode_current_mol) /
-                          cathode_target_mol
-                   << " % " << std::endl;
-    amrex::Print() << "    Electrolyte: current = " << electrolyte_current_mol
-                   << " mol , target = " << electrolyte_target_mol
-                   << " mol , error = "
-                   << 100 * (electrolyte_target_mol - electrolyte_current_mol) /
-                          electrolyte_target_mol
-                   << " % " << std::endl;
+    amrex::Print() << "    Anode      : current = " << anode_current_mol << " mol , target = " << anode_target_mol
+                   << " mol , error = " << 100 * (anode_target_mol - anode_current_mol) / anode_target_mol << " % " << std::endl;
+    amrex::Print() << "    Cathode    : current = " << cathode_current_mol << " mol , target = " << cathode_target_mol
+                   << " mol , error = " << 100 * (cathode_target_mol - cathode_current_mol) / cathode_target_mol << " % " << std::endl;
+    amrex::Print() << "    Electrolyte: current = " << electrolyte_current_mol << " mol , target = " << electrolyte_target_mol
+                   << " mol , error = " << 100 * (electrolyte_target_mol - electrolyte_current_mol) / electrolyte_target_mol << " % " << std::endl;
     amrex::Print() << std::endl;
 
     // Real test1 = SurfaceIntegral(-1, A_ID, E_ID);
@@ -528,32 +410,23 @@ void echemAMR::postprocess(
     // amrex::Print() << "Cathode-Electrolyte SA: " << test2 << std::endl;
     // amrex::Print() << std::endl;
 
-    if (line_plot_int > 0 &&
-        ((timestep + 1) % line_plot_int == 0 || timestep == 0)) {
+    if (line_plot_int > 0 && ((timestep + 1) % line_plot_int == 0 || timestep == 0))
+    {
         std::string co = "concentration";
         std::string po = "potential";
 
-        if (line_plot_dir == 0) {
-            line_plot(
-                XDir(), line_plot_npoints, time, timestep, finest_level, geom,
-                dmap, grids, phi_new, CO_ID, co);
-            line_plot(
-                XDir(), line_plot_npoints, time, timestep, finest_level, geom,
-                dmap, grids, phi_new, PO_ID, po);
-        } else if (line_plot_dir == 1) {
-            line_plot(
-                YDir(), line_plot_npoints, time, timestep, finest_level, geom,
-                dmap, grids, phi_new, CO_ID, co);
-            line_plot(
-                YDir(), line_plot_npoints, time, timestep, finest_level, geom,
-                dmap, grids, phi_new, PO_ID, po);
-        } else {
-            line_plot(
-                ZDir(), line_plot_npoints, time, timestep, finest_level, geom,
-                dmap, grids, phi_new, CO_ID, co);
-            line_plot(
-                ZDir(), line_plot_npoints, time, timestep, finest_level, geom,
-                dmap, grids, phi_new, PO_ID, po);
+        if (line_plot_dir == 0)
+        {
+            line_plot(XDir(), line_plot_npoints, time, timestep, finest_level, geom, dmap, grids, phi_new, CO_ID, co);
+            line_plot(XDir(), line_plot_npoints, time, timestep, finest_level, geom, dmap, grids, phi_new, PO_ID, po);
+        } else if (line_plot_dir == 1)
+        {
+            line_plot(YDir(), line_plot_npoints, time, timestep, finest_level, geom, dmap, grids, phi_new, CO_ID, co);
+            line_plot(YDir(), line_plot_npoints, time, timestep, finest_level, geom, dmap, grids, phi_new, PO_ID, po);
+        } else
+        {
+            line_plot(ZDir(), line_plot_npoints, time, timestep, finest_level, geom, dmap, grids, phi_new, CO_ID, co);
+            line_plot(ZDir(), line_plot_npoints, time, timestep, finest_level, geom, dmap, grids, phi_new, PO_ID, po);
         }
     }
 }

--- a/test/battery/Prob.H
+++ b/test/battery/Prob.H
@@ -35,16 +35,11 @@ void amrex_probinit(ProbParm& h_prob_parm, ProbParm& d_prob_parm)
     pp.query("cathode_soc_min", h_prob_parm.anode_soc_max);
 
     pp.query("lowerscale_vf_pore_anode", h_prob_parm.lowerscale_vf_pore_anode);
-    pp.query(
-        "lowerscale_vf_pore_separator",
-        h_prob_parm.lowerscale_vf_pore_separator);
-    pp.query(
-        "lowerscale_vf_pore_cathode", h_prob_parm.lowerscale_vf_pore_cathode);
+    pp.query("lowerscale_vf_pore_separator", h_prob_parm.lowerscale_vf_pore_separator);
+    pp.query("lowerscale_vf_pore_cathode", h_prob_parm.lowerscale_vf_pore_cathode);
     pp.query("lowerscale_p_pore_anode", h_prob_parm.lowerscale_p_pore_anode);
-    pp.query(
-        "lowerscale_p_pore_separator", h_prob_parm.lowerscale_p_pore_separator);
-    pp.query(
-        "lowerscale_p_pore_cathode", h_prob_parm.lowerscale_p_pore_cathode);
+    pp.query("lowerscale_p_pore_separator", h_prob_parm.lowerscale_p_pore_separator);
+    pp.query("lowerscale_p_pore_cathode", h_prob_parm.lowerscale_p_pore_cathode);
 
     pp.query("ce_atrest", h_prob_parm.ce_atrest);
     pp.query("soc_anode_t0", h_prob_parm.soc_anode_t0);
@@ -60,10 +55,8 @@ void amrex_probinit(ProbParm& h_prob_parm, ProbParm& d_prob_parm)
 
 AMREX_GPU_DEVICE
 AMREX_INLINE
-void initdomaindata(
-    Box const& bx,
-    Array4<Real> const& phi,
-    GeometryData const& geomdata) // break into multiple steps
+void initdomaindata(Box const& bx, Array4<Real> const& phi,
+                    GeometryData const& geomdata) // break into multiple steps
 {
     const auto lo = lbound(bx);
     const auto hi = ubound(bx);
@@ -82,15 +75,19 @@ void initdomaindata(
 #pragma omp parallel for collapse(2) if (GPU::notInLaunchRegion)
 #endif
 
-    for (int k = lo.z; k <= hi.z; ++k) {
+    for (int k = lo.z; k <= hi.z; ++k)
+    {
         const Real z = prob_lo[2] + (0.5 + k) * dx[2];
-        for (int j = lo.y; j <= hi.y; ++j) {
+        for (int j = lo.y; j <= hi.y; ++j)
+        {
             const Real y = prob_lo[1] + (0.5 + j) * dx[1];
             AMREX_PRAGMA_SIMD
-            for (int i = lo.x; i <= hi.x; ++i) {
+            for (int i = lo.x; i <= hi.x; ++i)
+            {
                 const Real x = prob_lo[0] + (0.5 + i) * dx[0];
 
-                for (int n = 0; n < ncomp; ++n) {
+                for (int n = 0; n < ncomp; ++n)
+                {
                     phi(i, j, k, n) = -1.0;
                 }
 
@@ -100,28 +97,30 @@ void initdomaindata(
                 const amrex::Real s_xhi = 0.55 * Lx;
 
                 bool comp_found = false;
-                for (int jj = 0; jj < 3; ++jj) {
+                for (int jj = 0; jj < 3; ++jj)
+                {
                     Real y0 = jj * Ly / 2.0;
-                    for (int kk = 0; kk < 3; ++kk) {
+                    for (int kk = 0; kk < 3; ++kk)
+                    {
                         Real z0 = kk * Lz / 2.0;
                         // cathode
-                        for (int ii = 0; ii < 5; ++ii) {
+                        for (int ii = 0; ii < 5; ++ii)
+                        {
                             Real x0 = ii * .35 * Lx / 4.0;
-                            Real r = std::sqrt(
-                                (x - x0) * (x - x0) + (y - y0) * (y - y0) +
-                                (z - z0) * (z - z0));
-                            if (r < Lx / 20.0) {
+                            Real r = std::sqrt((x - x0) * (x - x0) + (y - y0) * (y - y0) + (z - z0) * (z - z0));
+                            if (r < Lx / 20.0)
+                            {
                                 phi(i, j, k, C_ID) = 1.0;
                                 comp_found = true;
                             }
                         }
                         // anode
-                        for (int ii = 0; ii < 5; ++ii) {
+                        for (int ii = 0; ii < 5; ++ii)
+                        {
                             Real x0 = 0.65 * Lx + ii * .35 * Lx / 4.0;
-                            Real r = std::sqrt(
-                                (x - x0) * (x - x0) + (y - y0) * (y - y0) +
-                                (z - z0) * (z - z0));
-                            if (r < Lx / 20.0) {
+                            Real r = std::sqrt((x - x0) * (x - x0) + (y - y0) * (y - y0) + (z - z0) * (z - z0));
+                            if (r < Lx / 20.0)
+                            {
                                 phi(i, j, k, A_ID) = 1.0;
                                 comp_found = true;
                             }
@@ -129,11 +128,14 @@ void initdomaindata(
                     }
                 }
 
-                if (!comp_found) {
-                    if (x > s_xlo && x < s_xhi) {
+                if (!comp_found)
+                {
+                    if (x > s_xlo && x < s_xhi)
+                    {
                         // separator
                         phi(i, j, k, S_ID) = 1.0;
-                    } else {
+                    } else
+                    {
                         // electrolyte
                         phi(i, j, k, E_ID) = 1.0;
                     }
@@ -154,10 +156,8 @@ void initdomaindata(
 
 AMREX_GPU_DEVICE
 AMREX_INLINE
-void initproblemdata(
-    Box const& bx,
-    Array4<Real> const& phi,
-    GeometryData const& geomdata) // break into multiple steps
+void initproblemdata(Box const& bx, Array4<Real> const& phi,
+                     GeometryData const& geomdata) // break into multiple steps
 {
 
     const auto lo = lbound(bx);
@@ -182,65 +182,42 @@ void initproblemdata(
     // ------------------------
 
     // Calculate active material volumes
-    const amrex::Real volume_anode =
-        echemAMR::host_global_storage->anode_volume; // [m3]
-    const amrex::Real volume_cathode =
-        echemAMR::host_global_storage->cathode_volume; // [m3]
+    const amrex::Real volume_anode = echemAMR::host_global_storage->anode_volume;     // [m3]
+    const amrex::Real volume_cathode = echemAMR::host_global_storage->cathode_volume; // [m3]
 
     // Calculate anode and cathode theoritical (use full soc range) and pratical
     // (use a reduced soc range) capacity
     const amrex::Real Fday = echemAMR::d_prob_parm->Faraday_const; // [C.mol-1]
 
-    const amrex::Real Csmax_anode =
-        electrochem::Cs_max_anode(*echemAMR::d_prob_parm); // [mol.m-3]
-    const amrex::Real SOCrange_anode =
-        echemAMR::d_prob_parm->anode_soc_max -
-        echemAMR::d_prob_parm->anode_soc_min; // []
-    const amrex::Real theoritical_capacity_anode =
-        volume_anode * Csmax_anode * Fday; // [C]
-    const amrex::Real pratical_capacity_anode =
-        theoritical_capacity_anode * SOCrange_anode; // [C]
+    const amrex::Real Csmax_anode = electrochem::Cs_max_anode(*echemAMR::d_prob_parm);                              // [mol.m-3]
+    const amrex::Real SOCrange_anode = echemAMR::d_prob_parm->anode_soc_max - echemAMR::d_prob_parm->anode_soc_min; // []
+    const amrex::Real theoritical_capacity_anode = volume_anode * Csmax_anode * Fday;                               // [C]
+    const amrex::Real pratical_capacity_anode = theoritical_capacity_anode * SOCrange_anode;                        // [C]
 
-    const amrex::Real Csmax_cathode =
-        electrochem::Cs_max_cathode(*echemAMR::d_prob_parm); // [mol.m-3]
-    const amrex::Real SOCrange_cathode =
-        echemAMR::d_prob_parm->cathode_soc_max -
-        echemAMR::d_prob_parm->cathode_soc_min; // []
-    const amrex::Real theoritical_capacity_cathode =
-        volume_cathode * Csmax_cathode * Fday; // [C]
-    const amrex::Real pratical_capacity_cathode =
-        theoritical_capacity_cathode * SOCrange_cathode; // [C]
+    const amrex::Real Csmax_cathode = electrochem::Cs_max_cathode(*echemAMR::d_prob_parm);                                // [mol.m-3]
+    const amrex::Real SOCrange_cathode = echemAMR::d_prob_parm->cathode_soc_max - echemAMR::d_prob_parm->cathode_soc_min; // []
+    const amrex::Real theoritical_capacity_cathode = volume_cathode * Csmax_cathode * Fday;                               // [C]
+    const amrex::Real pratical_capacity_cathode = theoritical_capacity_cathode * SOCrange_cathode;                        // [C]
 
     // Deduce cell pratical capacity
-    const amrex::Real pratical_capacity_cell =
-        amrex::min(pratical_capacity_anode, pratical_capacity_cathode); // [C]
-    const amrex::Real Cell_NP_ratio =
-        pratical_capacity_anode /
-        pratical_capacity_cathode; // Not required, just FYI. Should be always
-                                   // >1 (if not, you can expect eartly
-                                   // degradation)
+    const amrex::Real pratical_capacity_cell = amrex::min(pratical_capacity_anode, pratical_capacity_cathode); // [C]
+    const amrex::Real Cell_NP_ratio = pratical_capacity_anode / pratical_capacity_cathode;                     // Not required, just FYI. Should be always
+                                                                                                               // >1 (if not, you can expect eartly
+                                                                                                               // degradation)
 
     // Applied current
     const amrex::Real Crate = echemAMR::d_prob_parm->Crate;
-    const amrex::Real time_to_charge =
-        (1 / Crate) * 3600; // [s] Time to charge or discharge the cell
-    const amrex::Real Current1C =
-        pratical_capacity_cell / 3600; // [A=C.s-1] Current for 1C
-    const amrex::Real Applied_current =
-        Current1C *
-        Crate; // [A] (but we need the applied current density in A.m-2)
+    const amrex::Real time_to_charge = (1 / Crate) * 3600;       // [s] Time to charge or discharge the cell
+    const amrex::Real Current1C = pratical_capacity_cell / 3600; // [A=C.s-1] Current for 1C
+    const amrex::Real Applied_current = Current1C * Crate;       // [A] (but we need the applied current density in A.m-2)
 
     // Copy current in echemAMR as it is needed for post-processing
     echemAMR::host_global_storage->Applied_current = Applied_current;
 
     // Surface calculations // FIX ME: add surface calculations from Jeff
     // post-processing
-    const amrex::Real surface_anodesolid_currentcollector =
-        echemAMR::host_global_storage
-            ->anode_cc_SA; // [m2], temporary value pi*((5e-6)^2)
-    const amrex::Real surface_cathodsolid_currentcollector =
-        echemAMR::host_global_storage
-            ->cathode_cc_SA; // [m2], temporary value pi*((5e-6)^2)
+    const amrex::Real surface_anodesolid_currentcollector = echemAMR::host_global_storage->anode_cc_SA;    // [m2], temporary value pi*((5e-6)^2)
+    const amrex::Real surface_cathodsolid_currentcollector = echemAMR::host_global_storage->cathode_cc_SA; // [m2], temporary value pi*((5e-6)^2)
     // const amrex::Real surface_anodesolid_currentcollector = 7.8540e-11; //
     // [m2], temporary value pi*((5e-6)^2) const amrex::Real
     // surface_cathodsolid_currentcollector = 7.8540e-11; // [m2], temporary
@@ -250,22 +227,16 @@ void initproblemdata(
     // collector These are the two Neumann Boundary conditions value applies at
     // the left and right extremities of the cell FIX ME: MICHAEL/HARI: could
     // you link g with these two values?
-    const amrex::Real Applied_current_density_anode =
-        Applied_current / surface_anodesolid_currentcollector; // [A.m-2]
-    const amrex::Real Applied_current_density_cathode =
-        Applied_current / surface_cathodsolid_currentcollector; // [A.m-2]
+    const amrex::Real Applied_current_density_anode = Applied_current / surface_anodesolid_currentcollector;    // [A.m-2]
+    const amrex::Real Applied_current_density_cathode = Applied_current / surface_cathodsolid_currentcollector; // [A.m-2]
 
-    echemAMR::host_global_storage->pot_bc_lo[0] =
-        -Applied_current_density_cathode;
-    echemAMR::host_global_storage->pot_bc_hi[0] =
-        -Applied_current_density_anode;
+    echemAMR::host_global_storage->pot_bc_lo[0] = -Applied_current_density_cathode;
+    echemAMR::host_global_storage->pot_bc_hi[0] = -Applied_current_density_anode;
 
     // Surface calculations // FIX ME: add surface calculations from Jeff
     // post-processing
-    const amrex::Real surface_anodesolid_electrolyte =
-        echemAMR::host_global_storage->anode_ele_SA; // 4*pi*((5e-6)^2)
-    const amrex::Real surface_cathodesolid_electrolyte =
-        echemAMR::host_global_storage->cathode_ele_SA; // 4*pi*((5e-6)^2)
+    const amrex::Real surface_anodesolid_electrolyte = echemAMR::host_global_storage->anode_ele_SA;     // 4*pi*((5e-6)^2)
+    const amrex::Real surface_cathodesolid_electrolyte = echemAMR::host_global_storage->cathode_ele_SA; // 4*pi*((5e-6)^2)
     // const amrex::Real surface_anodesolid_electrolyte = 3.1416e-10; //
     // 4*pi*((5e-6)^2) const amrex::Real surface_cathodesolid_electrolyte
     // = 3.1416e-10; // 4*pi*((5e-6)^2)
@@ -278,20 +249,15 @@ void initproblemdata(
     // integral(current density, ds active material-current collector) =
     // integral(current density, ds active material-electrolyte) will result in
     // an error in mass conservation
-    const amrex::Real Activeinterface_current_density_anode =
-        Applied_current / surface_anodesolid_electrolyte; // [A.m-2]
-    const amrex::Real Activeinterface_current_density_cathode =
-        Applied_current / surface_cathodesolid_electrolyte; // [A.m-2]
+    const amrex::Real Activeinterface_current_density_anode = Applied_current / surface_anodesolid_electrolyte;     // [A.m-2]
+    const amrex::Real Activeinterface_current_density_cathode = Applied_current / surface_cathodesolid_electrolyte; // [A.m-2]
 
     // Deduce potential values that verify this condition: Applied_current =
     // integral(current density, ds active material-current collector) =
     // integral(current density, ds active material-electrolyte)
-    const amrex::Real phie_to = electrochem::get_phie_initial_from_anode(
-        Activeinterface_current_density_anode,
-        echemAMR::d_prob_parm->phi_reference, *echemAMR::d_prob_parm);
-    const amrex::Real phi_c_to = electrochem::get_phic_initial_from_electrolyte(
-        Activeinterface_current_density_cathode, phie_to,
-        *echemAMR::d_prob_parm);
+    const amrex::Real phie_to =
+        electrochem::get_phie_initial_from_anode(Activeinterface_current_density_anode, echemAMR::d_prob_parm->phi_reference, *echemAMR::d_prob_parm);
+    const amrex::Real phi_c_to = electrochem::get_phic_initial_from_electrolyte(Activeinterface_current_density_cathode, phie_to, *echemAMR::d_prob_parm);
 
     // TO BE REMOVED
     // ProbParm h_prob_parm; // Create a new instance of the structure ProbParm
@@ -301,12 +267,15 @@ void initproblemdata(
     // dd_prob_parm = (ProbParm*)The_Arena()->alloc(sizeof(ProbParm));
     // amrex_probinit(*hh_prob_parm, *dd_prob_parm);
 
-    for (int k = lo.z; k <= hi.z; ++k) {
+    for (int k = lo.z; k <= hi.z; ++k)
+    {
         const Real z = prob_lo[2] + (0.5 + k) * dx[2];
-        for (int j = lo.y; j <= hi.y; ++j) {
+        for (int j = lo.y; j <= hi.y; ++j)
+        {
             const Real y = prob_lo[1] + (0.5 + j) * dx[1];
             AMREX_PRAGMA_SIMD
-            for (int i = lo.x; i <= hi.x; ++i) {
+            for (int i = lo.x; i <= hi.x; ++i)
+            {
                 const Real x = prob_lo[0] + (0.5 + i) * dx[0];
 
                 // FIXME: pass prob parm or more inputs so that we can have
@@ -323,54 +292,52 @@ void initproblemdata(
                 const amrex::Real c_x = 0.75 * Lx;
 
                 bool comp_found = false;
-                for (int jj = 0; jj < 3; ++jj) {
+                for (int jj = 0; jj < 3; ++jj)
+                {
                     Real y0 = jj * Ly / 2.0;
-                    for (int kk = 0; kk < 3; ++kk) {
+                    for (int kk = 0; kk < 3; ++kk)
+                    {
                         Real z0 = kk * Lz / 2.0;
                         // cathode
-                        for (int ii = 0; ii < 5; ++ii) {
+                        for (int ii = 0; ii < 5; ++ii)
+                        {
                             Real x0 = ii * .35 * Lx / 4.0;
-                            Real r = std::sqrt(
-                                (x - x0) * (x - x0) + (y - y0) * (y - y0) +
-                                (z - z0) * (z - z0));
-                            if (r < Lx / 20.0) {
-                                const amrex::Real soc_init =
-                                    echemAMR::d_prob_parm->soc_cathode_t0;
-                                const amrex::Real csmax =
-                                    electrochem::Cs_max_cathode(
-                                        *echemAMR::d_prob_parm);
+                            Real r = std::sqrt((x - x0) * (x - x0) + (y - y0) * (y - y0) + (z - z0) * (z - z0));
+                            if (r < Lx / 20.0)
+                            {
+                                const amrex::Real soc_init = echemAMR::d_prob_parm->soc_cathode_t0;
+                                const amrex::Real csmax = electrochem::Cs_max_cathode(*echemAMR::d_prob_parm);
                                 phi(i, j, k, CO_ID) = soc_init * csmax;
                                 phi(i, j, k, PO_ID) = phi_c_to;
                                 comp_found = true;
                             }
                         }
                         // anode
-                        for (int ii = 0; ii < 5; ++ii) {
+                        for (int ii = 0; ii < 5; ++ii)
+                        {
                             Real x0 = 0.65 * Lx + ii * .35 * Lx / 4.0;
-                            Real r = std::sqrt(
-                                (x - x0) * (x - x0) + (y - y0) * (y - y0) +
-                                (z - z0) * (z - z0));
-                            if (r < Lx / 20.0) {
-                                const amrex::Real soc_init =
-                                    echemAMR::d_prob_parm->soc_anode_t0;
-                                const amrex::Real csmax =
-                                    electrochem::Cs_max_anode(
-                                        *echemAMR::d_prob_parm);
+                            Real r = std::sqrt((x - x0) * (x - x0) + (y - y0) * (y - y0) + (z - z0) * (z - z0));
+                            if (r < Lx / 20.0)
+                            {
+                                const amrex::Real soc_init = echemAMR::d_prob_parm->soc_anode_t0;
+                                const amrex::Real csmax = electrochem::Cs_max_anode(*echemAMR::d_prob_parm);
                                 phi(i, j, k, CO_ID) = soc_init * csmax;
-                                phi(i, j, k, PO_ID) =
-                                    echemAMR::d_prob_parm->phi_reference;
+                                phi(i, j, k, PO_ID) = echemAMR::d_prob_parm->phi_reference;
                                 comp_found = true;
                             }
                         }
                     }
                 }
 
-                if (!comp_found) {
-                    if (x > s_xlo && x < s_xhi) {
+                if (!comp_found)
+                {
+                    if (x > s_xlo && x < s_xhi)
+                    {
                         // separator
                         phi(i, j, k, CO_ID) = echemAMR::d_prob_parm->ce_atrest;
                         phi(i, j, k, PO_ID) = phie_to;
-                    } else {
+                    } else
+                    {
                         // electrolyte
                         phi(i, j, k, CO_ID) = echemAMR::d_prob_parm->ce_atrest;
                         phi(i, j, k, PO_ID) = phie_to;
@@ -396,81 +363,54 @@ void print_init_data() // break into multiple steps
     // Calculate active material volumes
     // echemAMR::post_timestep(0, 0); // FIX ME: add volume calculation from
     // Jeff post-processing
-    const amrex::Real volume_anode =
-        echemAMR::host_global_storage->anode_volume; // [m3]
-    const amrex::Real volume_cathode =
-        echemAMR::host_global_storage->cathode_volume; // [m3]
+    const amrex::Real volume_anode = echemAMR::host_global_storage->anode_volume;     // [m3]
+    const amrex::Real volume_cathode = echemAMR::host_global_storage->cathode_volume; // [m3]
 
     // Calculate anode and cathode theoritical (use full soc range) and pratical
     // (use a reduced soc range) capacity
     const amrex::Real Fday = echemAMR::d_prob_parm->Faraday_const; // [C.mol-1]
 
-    const amrex::Real Csmax_anode =
-        electrochem::Cs_max_anode(*echemAMR::d_prob_parm); // [mol.m-3]
-    const amrex::Real SOCrange_anode =
-        echemAMR::d_prob_parm->anode_soc_max -
-        echemAMR::d_prob_parm->anode_soc_min; // []
-    const amrex::Real theoritical_capacity_anode =
-        volume_anode * Csmax_anode * Fday; // [C]
-    const amrex::Real pratical_capacity_anode =
-        theoritical_capacity_anode * SOCrange_anode; // [C]
+    const amrex::Real Csmax_anode = electrochem::Cs_max_anode(*echemAMR::d_prob_parm);                              // [mol.m-3]
+    const amrex::Real SOCrange_anode = echemAMR::d_prob_parm->anode_soc_max - echemAMR::d_prob_parm->anode_soc_min; // []
+    const amrex::Real theoritical_capacity_anode = volume_anode * Csmax_anode * Fday;                               // [C]
+    const amrex::Real pratical_capacity_anode = theoritical_capacity_anode * SOCrange_anode;                        // [C]
 
-    const amrex::Real Csmax_cathode =
-        electrochem::Cs_max_cathode(*echemAMR::d_prob_parm); // [mol.m-3]
-    const amrex::Real SOCrange_cathode =
-        echemAMR::d_prob_parm->cathode_soc_max -
-        echemAMR::d_prob_parm->cathode_soc_min; // []
-    const amrex::Real theoritical_capacity_cathode =
-        volume_cathode * Csmax_cathode * Fday; // [C]
-    const amrex::Real pratical_capacity_cathode =
-        theoritical_capacity_cathode * SOCrange_cathode; // [C]
+    const amrex::Real Csmax_cathode = electrochem::Cs_max_cathode(*echemAMR::d_prob_parm);                                // [mol.m-3]
+    const amrex::Real SOCrange_cathode = echemAMR::d_prob_parm->cathode_soc_max - echemAMR::d_prob_parm->cathode_soc_min; // []
+    const amrex::Real theoritical_capacity_cathode = volume_cathode * Csmax_cathode * Fday;                               // [C]
+    const amrex::Real pratical_capacity_cathode = theoritical_capacity_cathode * SOCrange_cathode;                        // [C]
 
     // Deduce cell pratical capacity
-    const amrex::Real pratical_capacity_cell =
-        amrex::min(pratical_capacity_anode, pratical_capacity_cathode); // [C]
-    const amrex::Real Cell_NP_ratio =
-        pratical_capacity_anode /
-        pratical_capacity_cathode; // Not required, just FYI. Should be always
-                                   // >1 (if not, you can expect eartly
-                                   // degradation)
+    const amrex::Real pratical_capacity_cell = amrex::min(pratical_capacity_anode, pratical_capacity_cathode); // [C]
+    const amrex::Real Cell_NP_ratio = pratical_capacity_anode / pratical_capacity_cathode;                     // Not required, just FYI. Should be always
+                                                                                                               // >1 (if not, you can expect eartly
+                                                                                                               // degradation)
 
     // Applied current
     const amrex::Real Crate = echemAMR::d_prob_parm->Crate;
-    const amrex::Real time_to_charge =
-        (1 / Crate) * 3600; // [s] Time to charge or discharge the cell
-    const amrex::Real Current1C =
-        pratical_capacity_cell / 3600; // [A=C.s-1] Current for 1C
-    const amrex::Real Applied_current =
-        Current1C *
-        Crate; // [A] (but we need the applied current density in A.m-2)
+    const amrex::Real time_to_charge = (1 / Crate) * 3600;       // [s] Time to charge or discharge the cell
+    const amrex::Real Current1C = pratical_capacity_cell / 3600; // [A=C.s-1] Current for 1C
+    const amrex::Real Applied_current = Current1C * Crate;       // [A] (but we need the applied current density in A.m-2)
 
     // Copy current in echemAMR as it is needed for post-processing
     echemAMR::host_global_storage->Applied_current = Applied_current;
 
     // Surface calculations // FIX ME: add surface calculations from Jeff
     // post-processing
-    const amrex::Real surface_anodesolid_currentcollector =
-        echemAMR::host_global_storage
-            ->anode_cc_SA; // [m2], temporary value pi*((5e-6)^2)
-    const amrex::Real surface_cathodsolid_currentcollector =
-        echemAMR::host_global_storage
-            ->cathode_cc_SA; // [m2], temporary value pi*((5e-6)^2)
+    const amrex::Real surface_anodesolid_currentcollector = echemAMR::host_global_storage->anode_cc_SA;    // [m2], temporary value pi*((5e-6)^2)
+    const amrex::Real surface_cathodsolid_currentcollector = echemAMR::host_global_storage->cathode_cc_SA; // [m2], temporary value pi*((5e-6)^2)
 
     // Applied current density at the interface active material - current
     // collector These are the two Neumann Boundary conditions value applies at
     // the left and right extremities of the cell FIX ME: MICHAEL/HARI: could
     // you link g with these two values?
-    const amrex::Real Applied_current_density_anode =
-        Applied_current / surface_anodesolid_currentcollector; // [A.m-2]
-    const amrex::Real Applied_current_density_cathode =
-        Applied_current / surface_cathodsolid_currentcollector; // [A.m-2]
+    const amrex::Real Applied_current_density_anode = Applied_current / surface_anodesolid_currentcollector;    // [A.m-2]
+    const amrex::Real Applied_current_density_cathode = Applied_current / surface_cathodsolid_currentcollector; // [A.m-2]
 
     // Surface calculations // FIX ME: add surface calculations from Jeff
     // post-processing
-    const amrex::Real surface_anodesolid_electrolyte =
-        echemAMR::host_global_storage->anode_ele_SA; // 4*pi*((5e-6)^2)
-    const amrex::Real surface_cathodesolid_electrolyte =
-        echemAMR::host_global_storage->cathode_ele_SA; // 4*pi*((5e-6)^2)
+    const amrex::Real surface_anodesolid_electrolyte = echemAMR::host_global_storage->anode_ele_SA;     // 4*pi*((5e-6)^2)
+    const amrex::Real surface_cathodesolid_electrolyte = echemAMR::host_global_storage->cathode_ele_SA; // 4*pi*((5e-6)^2)
 
     // Initial current density at the interface active material - electrolyte
     // These are the two Neumann Boundary conditions value applied at the active
@@ -480,86 +420,52 @@ void print_init_data() // break into multiple steps
     // integral(current density, ds active material-current collector) =
     // integral(current density, ds active material-electrolyte) will result in
     // an error in mass conservation
-    const amrex::Real Activeinterface_current_density_anode =
-        Applied_current / surface_anodesolid_electrolyte; // [A.m-2]
-    const amrex::Real Activeinterface_current_density_cathode =
-        Applied_current / surface_cathodesolid_electrolyte; // [A.m-2]
+    const amrex::Real Activeinterface_current_density_anode = Applied_current / surface_anodesolid_electrolyte;     // [A.m-2]
+    const amrex::Real Activeinterface_current_density_cathode = Applied_current / surface_cathodesolid_electrolyte; // [A.m-2]
 
     // Deduce potential values that verify this condition: Applied_current =
     // integral(current density, ds active material-current collector) =
     // integral(current density, ds active material-electrolyte)
-    const amrex::Real phie_to = electrochem::get_phie_initial_from_anode(
-        Activeinterface_current_density_anode,
-        echemAMR::d_prob_parm->phi_reference, *echemAMR::d_prob_parm);
-    const amrex::Real phi_c_to = electrochem::get_phic_initial_from_electrolyte(
-        Activeinterface_current_density_cathode, phie_to,
-        *echemAMR::d_prob_parm);
+    const amrex::Real phie_to =
+        electrochem::get_phie_initial_from_anode(Activeinterface_current_density_anode, echemAMR::d_prob_parm->phi_reference, *echemAMR::d_prob_parm);
+    const amrex::Real phi_c_to = electrochem::get_phic_initial_from_electrolyte(Activeinterface_current_density_cathode, phie_to, *echemAMR::d_prob_parm);
 
     amrex::Print() << std::endl;
     amrex::Print() << "CAPACITY" << std::endl;
     amrex::Print() << "Anode                     " << std::endl;
-    amrex::Print() << "- Active material volume: " << volume_anode << " [m3] "
-                   << std::endl;
-    amrex::Print() << "- Theoritical capacity  : " << theoritical_capacity_anode
-                   << " [C] " << std::endl;
-    amrex::Print() << "- SOC delta range       : " << SOCrange_anode
-                   << std::endl;
-    amrex::Print() << "- Pratical capacity     : " << pratical_capacity_anode
-                   << " [C] " << std::endl;
+    amrex::Print() << "- Active material volume: " << volume_anode << " [m3] " << std::endl;
+    amrex::Print() << "- Theoritical capacity  : " << theoritical_capacity_anode << " [C] " << std::endl;
+    amrex::Print() << "- SOC delta range       : " << SOCrange_anode << std::endl;
+    amrex::Print() << "- Pratical capacity     : " << pratical_capacity_anode << " [C] " << std::endl;
     amrex::Print() << "Cathode                   " << std::endl;
-    amrex::Print() << "- Active material volume: " << volume_cathode << " [m3] "
-                   << std::endl;
-    amrex::Print() << "- Theoritical capacity  : "
-                   << theoritical_capacity_cathode << " [C] " << std::endl;
-    amrex::Print() << "- SOC delta range       : " << SOCrange_cathode
-                   << std::endl;
-    amrex::Print() << "- Pratical capacity     : " << pratical_capacity_cathode
-                   << " [C] " << std::endl;
+    amrex::Print() << "- Active material volume: " << volume_cathode << " [m3] " << std::endl;
+    amrex::Print() << "- Theoritical capacity  : " << theoritical_capacity_cathode << " [C] " << std::endl;
+    amrex::Print() << "- SOC delta range       : " << SOCrange_cathode << std::endl;
+    amrex::Print() << "- Pratical capacity     : " << pratical_capacity_cathode << " [C] " << std::endl;
     amrex::Print() << "Cell                      " << std::endl;
-    amrex::Print() << "- N/P ratio             : " << Cell_NP_ratio
-                   << std::endl;
-    amrex::Print() << "- Pratical capacity     : " << pratical_capacity_cell
-                   << " [C] " << std::endl;
+    amrex::Print() << "- N/P ratio             : " << Cell_NP_ratio << std::endl;
+    amrex::Print() << "- Pratical capacity     : " << pratical_capacity_cell << " [C] " << std::endl;
     amrex::Print() << std::endl;
     amrex::Print() << "CURRENT" << std::endl;
     amrex::Print() << "Cell                     " << std::endl;
     amrex::Print() << "- C-rate                : " << Crate << std::endl;
-    amrex::Print() << "- Time to (dis)charge   : " << time_to_charge << " [s] "
-                   << std::endl;
-    amrex::Print() << "- Applied current       : " << Applied_current << " [A] "
-                   << std::endl;
+    amrex::Print() << "- Time to (dis)charge   : " << time_to_charge << " [s] " << std::endl;
+    amrex::Print() << "- Applied current       : " << Applied_current << " [A] " << std::endl;
     amrex::Print() << "Anode                     " << std::endl;
-    amrex::Print() << "- active material - current collector interface: "
-                   << surface_anodesolid_currentcollector << " [m2] "
-                   << std::endl;
-    amrex::Print() << "- Applied current density                      : "
-                   << Applied_current_density_anode << " [A.m-2] " << std::endl;
-    amrex::Print() << "- active material - electrolyte interface      : "
-                   << surface_anodesolid_electrolyte << " [m2] " << std::endl;
-    amrex::Print() << "- Current density at the active interface      : "
-                   << Activeinterface_current_density_anode << " [A.m-2] "
-                   << std::endl;
+    amrex::Print() << "- active material - current collector interface: " << surface_anodesolid_currentcollector << " [m2] " << std::endl;
+    amrex::Print() << "- Applied current density                      : " << Applied_current_density_anode << " [A.m-2] " << std::endl;
+    amrex::Print() << "- active material - electrolyte interface      : " << surface_anodesolid_electrolyte << " [m2] " << std::endl;
+    amrex::Print() << "- Current density at the active interface      : " << Activeinterface_current_density_anode << " [A.m-2] " << std::endl;
     amrex::Print() << "Cathode                     " << std::endl;
-    amrex::Print() << "- active material - current collector interface: "
-                   << surface_cathodsolid_currentcollector << " [m2] "
-                   << std::endl;
-    amrex::Print() << "- Applied current density                      : "
-                   << Applied_current_density_cathode << " [A.m-2] "
-                   << std::endl;
-    amrex::Print() << "- active material - electrolyte interface      : "
-                   << surface_cathodesolid_electrolyte << " [m2] " << std::endl;
-    amrex::Print() << "- Current density at the active interface      : "
-                   << Activeinterface_current_density_cathode << " [A.m-2] "
-                   << std::endl;
+    amrex::Print() << "- active material - current collector interface: " << surface_cathodsolid_currentcollector << " [m2] " << std::endl;
+    amrex::Print() << "- Applied current density                      : " << Applied_current_density_cathode << " [A.m-2] " << std::endl;
+    amrex::Print() << "- active material - electrolyte interface      : " << surface_cathodesolid_electrolyte << " [m2] " << std::endl;
+    amrex::Print() << "- Current density at the active interface      : " << Activeinterface_current_density_cathode << " [A.m-2] " << std::endl;
     amrex::Print() << std::endl;
     amrex::Print() << "POTENTIAL INITALIZATION" << std::endl;
-    amrex::Print() << "- Anode reference potential : "
-                   << echemAMR::d_prob_parm->phi_reference << " [V] "
-                   << std::endl;
-    amrex::Print() << "- Electrolyte potential     : " << phie_to << " [V] "
-                   << std::endl;
-    amrex::Print() << "- Cathode potential         : " << phi_c_to << " [V] "
-                   << std::endl;
+    amrex::Print() << "- Anode reference potential : " << echemAMR::d_prob_parm->phi_reference << " [V] " << std::endl;
+    amrex::Print() << "- Electrolyte potential     : " << phie_to << " [V] " << std::endl;
+    amrex::Print() << "- Cathode potential         : " << phi_c_to << " [V] " << std::endl;
 }
 
 AMREX_GPU_DEVICE
@@ -574,7 +480,8 @@ void externalbc(
     amrex::GeometryData const& geomdata)
 {
     // default to extrapolation
-    for (int c = 0; c < NVAR; c++) {
+    for (int c = 0; c < NVAR; c++)
+    {
         s_ext[c] = s_int[c];
     }
 
@@ -582,7 +489,8 @@ void externalbc(
     {
         s_ext[CO_ID] = 0.0;
         s_ext[PO_ID] = 1.0;
-    } else {
+    } else
+    {
         s_ext[CO_ID] = 0.0;
         s_ext[PO_ID] = 0.0;
     }

--- a/test/battery/Reactions.H
+++ b/test/battery/Reactions.H
@@ -24,19 +24,17 @@ AMREX_GPU_DEVICE AMREX_INLINE void compute_react_source(
     ProbParm const& prob_parm)
 {
 
-    for (int n = 0; n < reactsource.nComp(); ++n) {
+    for (int n = 0; n < reactsource.nComp(); ++n)
+    {
         reactsource(i, j, k, n) = 0.0;
     }
 
     /* add intercalation reaction */
-    for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+    for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
+    {
         amrex::Real normal = 1.0 / dx[dir];
-        reactsource(i, j, k, CO_ID) +=
-            electrochem::ic_reaction(i, j, k, dir, +normal, phi, prob_parm) /
-            prob_parm.Faraday_const;
-        reactsource(i, j, k, CO_ID) +=
-            electrochem::ic_reaction(i, j, k, dir, -normal, phi, prob_parm) /
-            prob_parm.Faraday_const;
+        reactsource(i, j, k, CO_ID) += electrochem::ic_reaction(i, j, k, dir, +normal, phi, prob_parm) / prob_parm.Faraday_const;
+        reactsource(i, j, k, CO_ID) += electrochem::ic_reaction(i, j, k, dir, -normal, phi, prob_parm) / prob_parm.Faraday_const;
     }
 }
 
@@ -54,17 +52,18 @@ AMREX_GPU_DEVICE AMREX_INLINE void compute_potential_source(
 {
 
     // FIXME: add Neummann bc's to potential and concentration source terms
-    if (electrochem::is_electrode(i, j, k, phi)) {
+    if (electrochem::is_electrode(i, j, k, phi))
+    {
 
         potsource(i, j, k) = 0.0;
 
-    } else {
+    } else
+    {
 
         // concentration
         const Real Ce = phi(i, j, k, CO_ID);
-        const Real KD =
-            electrochem::K_D(Ce, prob_parm); // KD is either KD or KDstar as a
-                                             // function of prob_parm.use_KDstar
+        const Real KD = electrochem::K_D(Ce, prob_parm); // KD is either KD or KDstar as a
+                                                         // function of prob_parm.use_KDstar
 
         // FIXME: should probably average KD over faces but for now use use
         // value at center
@@ -72,25 +71,17 @@ AMREX_GPU_DEVICE AMREX_INLINE void compute_potential_source(
         // FIXME: this should be KDstar // Is KDstar or KD depending on
         // prob_parm.use_KDstar
         // FIXME: need to account for walls
-        potsource(i, j, k) =
-            KD * ((phi(i - 1, j, k, CO_ID) - 2.0 * phi(i, j, k, CO_ID) +
-                   phi(i + 1, j, k, CO_ID)) /
-                      dx[0] / dx[0] +
-                  (phi(i, j - 1, k, CO_ID) - 2.0 * phi(i, j, k, CO_ID) +
-                   phi(i, j + 1, k, CO_ID)) /
-                      dx[1] / dx[1] +
-                  (phi(i, j, k - 1, CO_ID) - 2.0 * phi(i, j, k, CO_ID) +
-                   phi(i, j, k + 1, CO_ID)) /
-                      dx[2] / dx[2]);
+        potsource(i, j, k) = KD * ((phi(i - 1, j, k, CO_ID) - 2.0 * phi(i, j, k, CO_ID) + phi(i + 1, j, k, CO_ID)) / dx[0] / dx[0] +
+                                   (phi(i, j - 1, k, CO_ID) - 2.0 * phi(i, j, k, CO_ID) + phi(i, j + 1, k, CO_ID)) / dx[1] / dx[1] +
+                                   (phi(i, j, k - 1, CO_ID) - 2.0 * phi(i, j, k, CO_ID) + phi(i, j, k + 1, CO_ID)) / dx[2] / dx[2]);
     }
 
     /* add intercalation reaction */
-    for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+    for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
+    {
         amrex::Real normal = 1.0 / dx[dir];
-        potsource(i, j, k) +=
-            electrochem::ic_reaction(i, j, k, dir, +normal, phi, prob_parm);
-        potsource(i, j, k) +=
-            electrochem::ic_reaction(i, j, k, dir, -normal, phi, prob_parm);
+        potsource(i, j, k) += electrochem::ic_reaction(i, j, k, dir, +normal, phi, prob_parm);
+        potsource(i, j, k) += electrochem::ic_reaction(i, j, k, dir, -normal, phi, prob_parm);
     }
 }
 

--- a/test/battery/Transport.H
+++ b/test/battery/Transport.H
@@ -21,46 +21,44 @@ AMREX_GPU_DEVICE AMREX_INLINE void compute_dcoeff(
     ProbParm const& prob_parm)
 {
 
-    for (int n = 0; n < phi.nComp(); ++n) {
+    for (int n = 0; n < phi.nComp(); ++n)
+    {
         dcoeff(i, j, k, n) = 0.0;
     }
 
     const int comp = electrochem::level_set_to_component(i, j, k, phi);
 
-    if (comp == electrochem::cathode) {
-        const Real Cs = phi(i, j, k, CO_ID); // cathode solid concentration
-        dcoeff(i, j, k, CO_ID) = electrochem::Dc_bulk(
-            Cs, prob_parm); // Cathode diffusion coefficient
+    if (comp == electrochem::cathode)
+    {
+        const Real Cs = phi(i, j, k, CO_ID);                          // cathode solid concentration
+        dcoeff(i, j, k, CO_ID) = electrochem::Dc_bulk(Cs, prob_parm); // Cathode diffusion coefficient
 
-    } else if (comp == electrochem::anode) {
-        const Real Cs = phi(i, j, k, CO_ID); // anode solid concentration
-        dcoeff(i, j, k, CO_ID) = electrochem::Da_bulk(
-            Cs, prob_parm); // Cathode diffusion coefficient
+    } else if (comp == electrochem::anode)
+    {
+        const Real Cs = phi(i, j, k, CO_ID);                          // anode solid concentration
+        dcoeff(i, j, k, CO_ID) = electrochem::Da_bulk(Cs, prob_parm); // Cathode diffusion coefficient
 
-    } else {
+    } else
+    {
 
         /* electrolyte or separator */
         const Real Ce = phi(i, j, k, CO_ID); // concentration
 
         const Real DeC = electrochem::De_C(Ce, prob_parm);
         const Real tplus = electrochem::t_plus(Ce, prob_parm);
-        const Real KD =
-            electrochem::K_D(Ce, prob_parm); // KD is either KD or KDstar as a
-                                             // function of prob_parm.use_KDstar
+        const Real KD = electrochem::K_D(Ce, prob_parm); // KD is either KD or KDstar as a
+                                                         // function of prob_parm.use_KDstar
 
-        if (prob_parm.use_KDstar) {
-            dcoeff(i, j, k, CO_ID) =
-                DeC -
-                tplus * KD /
-                    prob_parm
-                        .Faraday_const; // QUESTION: The concentration flux is
-                                        // -dcoeff*grad(Ce) -t/F*conductivity
-                                        // coefficient*grad(phie). In the code,
-                                        // is -t/F*conductivity
-                                        // coefficient*grad(phie) considered ?
-        } else {
-            dcoeff(i, j, k, CO_ID) =
-                1.0; // Use the baseline Dec - t/F*Kd*grad(ln(Ce))
+        if (prob_parm.use_KDstar)
+        {
+            dcoeff(i, j, k, CO_ID) = DeC - tplus * KD / prob_parm.Faraday_const; // QUESTION: The concentration flux is
+                                                                                 // -dcoeff*grad(Ce) -t/F*conductivity
+                                                                                 // coefficient*grad(phie). In the code,
+                                                                                 // is -t/F*conductivity
+                                                                                 // coefficient*grad(phie) considered ?
+        } else
+        {
+            dcoeff(i, j, k, CO_ID) = 1.0; // Use the baseline Dec - t/F*Kd*grad(ln(Ce))
         }
     }
 }
@@ -80,19 +78,20 @@ AMREX_GPU_DEVICE AMREX_INLINE void compute_potential_dcoeff(
 
     const int comp = electrochem::level_set_to_component(i, j, k, phi);
 
-    if (comp == electrochem::cathode) {
-        const Real Cs = phi(i, j, k, CO_ID); // cathode solid concentration
-        dcoeff(i, j, k) = electrochem::Kc_bulk(
-            Cs, prob_parm); // Cathode diffusion coefficient
+    if (comp == electrochem::cathode)
+    {
+        const Real Cs = phi(i, j, k, CO_ID);                   // cathode solid concentration
+        dcoeff(i, j, k) = electrochem::Kc_bulk(Cs, prob_parm); // Cathode diffusion coefficient
         // dcoeff(i,j,k) = prob_parm.K_c; // QUESTION: why dcoeff(i,j,k) and not
         // dcoeff(i,j,k,CO_ID) as done for the diffusion coefficient?
 
-    } else if (comp == electrochem::anode) {
-        const Real Cs = phi(i, j, k, CO_ID); // anode solid concentration
-        dcoeff(i, j, k) = electrochem::Ka_bulk(
-            Cs, prob_parm); // Cathode diffusion coefficient
+    } else if (comp == electrochem::anode)
+    {
+        const Real Cs = phi(i, j, k, CO_ID);                   // anode solid concentration
+        dcoeff(i, j, k) = electrochem::Ka_bulk(Cs, prob_parm); // Cathode diffusion coefficient
 
-    } else {
+    } else
+    {
 
         /* electrolyte or separator */
         // QUESTION: this time we use the conductivity coefficient, while the
@@ -127,10 +126,12 @@ AMREX_GPU_DEVICE AMREX_INLINE void potential_bc(
     const int km1 = (dir == 2) ? k - 1 : k;
 
     bool electrode = false;
-    if (sgn == -1) { // lo sides
+    if (sgn == -1)
+    { // lo sides
         electrode = electrochem::is_electrode(i, j, k, phi);
         bc(im1, jm1, km1) = (electrode) ? bclo : 0.0;
-    } else { // hi sides
+    } else
+    { // hi sides
         electrode = electrochem::is_electrode(im1, jm1, km1, phi);
         bc(i, j, k) = (electrode) ? bchi : 0.0;
     }
@@ -148,7 +149,8 @@ AMREX_GPU_DEVICE AMREX_INLINE void compute_velx(
     const Real time,
     ProbParm const& prob_parm)
 {
-    for (int n = 0; n < phi.nComp(); ++n) {
+    for (int n = 0; n < phi.nComp(); ++n)
+    {
         velx(i, j, k, n) = 0.0;
     }
 
@@ -174,7 +176,8 @@ AMREX_GPU_DEVICE AMREX_INLINE void compute_vely(
     const Real time,
     ProbParm const& prob_parm)
 {
-    for (int n = 0; n < phi.nComp(); ++n) {
+    for (int n = 0; n < phi.nComp(); ++n)
+    {
         vely(i, j, k, n) = 0.0;
     }
 
@@ -198,7 +201,8 @@ AMREX_GPU_DEVICE AMREX_INLINE void compute_velz(
     const Real time,
     ProbParm const& prob_parm)
 {
-    for (int n = 0; n < phi.nComp(); ++n) {
+    for (int n = 0; n < phi.nComp(); ++n)
+    {
         velz(i, j, k, n) = 0.0;
     }
 


### PR DESCRIPTION
- to use in the future type in main echemAMR directory : clang-format -i Source/name_of_file
- there is a hidden file called .clang-format that does the formatting
- if you want to override clang format use:

// clang-format off
code here
// clang-format on